### PR TITLE
tetris: the wider well (cols parameterization, pending receipts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,11 @@ minivac.greg.technology (push to main = deploy via github pages action).
 ## commands
 
 - `npm run check` = lint + typecheck + full test suite. run it as the gate.
+- deploy gate (2026-08-20, user-blessed): fast suite green + the 5000-circuit
+  dense-vs-fast sweep (`MINIVAC_MASS=1 npx vitest --run
+  src/simulator/tests/sparse-mass-validation.test.ts`, ~5-10 min). the 47-min
+  dense game scenario is an OCCASIONAL overnight receipt, not per-deploy —
+  zero engine disagreements ever recorded (max diff ~1e-10 mA).
 - `MINIVAC_SOLVER=dense npm run test -- --run` = whole suite under the dense
   oracle engine (do this after touching anything numerical).
 - `MINIVAC_MASS=1 npx vitest --run src/simulator/tests/sparse-mass-validation.test.ts`
@@ -62,7 +67,13 @@ M10/M11 — multivac tests enforce via assertJackCapacity().
   the book IV flip-flop, which toggles through the buzz).
 - capacitors: real (500uF sections 1-5, 1000uF section 6, jack notation
   `1cap`..`6cap`), backward-euler companions; time advances only via
-  stepTime(ms) — nothing in the browser calls it yet.
+  stepTime(ms). KNOWN LIMIT: a self-oscillating relay circuit's transition
+  relaxations FLUTTER under stepTime (the companion is a soft resistor at
+  game dt), and every flutter cycle reaches downstream relays as a real
+  edge — 3-4 game ticks in one solve; reproduced identically with a
+  follower relay and a two-cap astable. so the oscillator is a physics
+  demo (engine-parity-exact), NOT the game clock: the page's auto-gravity
+  cycles the tick slide on a timer (operator cadence, proven single-step).
 - multivac: machineCount ctor arg; canonical wire prefix `m12.3G` (numeric,
   0-based, unbounded), letters a.-h. are legacy aliases for m0-m7; per-machine
   supplies; negative rails common; machine 0 unprefixed internally.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -545,9 +545,30 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    pos mirrors as two-hot-at-boot). receipts: the 12-state walk, L2+J2
    locks stacked on each other's stems, T2 steering refused-then-allowed
    under a tower, file/check/playwright green. 502 relays / 85 machines.
-   NEXT: deploy the whole ring arc once the restructured receipts land;
-   then the ladder's next rungs — the canvas multivac viewer, column
-   scaling (a wider well), or capacitor-timed self-ticking.
+   THE MACHINE TICKS ITSELF (3b-5) LANDED 2026-08-20, same session:
+   CAPACITOR GRAVITY. a two-relay slow-release oscillator on the REAL
+   capacitor bank — TOSC's coil parallels four paralleled 500uF sections
+   and is fed through TDRV's NC; TDRV follows TOSC and its second set
+   bridges + onto the tick net exactly as the tick slide's closure does
+   (the compatibility-OR again — the slide stays live). under stepTime:
+   the supply recharges the bank in ONE backward-euler step (A-stable,
+   no overshoot), the pair latches tick-HIGH while the bank drains
+   through the 55-ohm coil (~hundreds of ms), and the dropout transition
+   BUZZES — a real relay oscillator buzzes; the chatter pins de-energized
+   (the device-verified book-IV class) leaving one clean tick-LOW step,
+   then the cycle repeats. AUTO = the slide on TOSC's own section; the
+   two relays landed exactly in m83's last two free sections (504 relays,
+   still 85 machines). the page's 'a' key opens the time faucet (an
+   interval feeding wall-clock dt into stepTime) — the OSCILLATOR does
+   all the ticking, lock bookkeeping included; steering and reshaping
+   keep working mid-fall. receipts: engine parity on the oscillator
+   (sparse and fast agree edge-for-edge and cap-voltage-exact), hands-off
+   gameplay from a single START press, AUTO-off freezes gravity, whole
+   file + check + playwright hands-off scenario green. the scratch
+   experiment that gated the design: the first stepTime run ever to
+   drive the game (nothing in the browser had called it before).
+   NEXT: deploy the two pending arcs as receipts land; then the canvas
+   multivac viewer or column scaling (a wider well).
 
 ## display/input notes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -597,7 +597,12 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    driver, file/check green. no circuit changes (page + tests only).
    NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
    overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
-   batch); then column scaling (a wider well).
+   batch); then column scaling (a wider well) — IN PROGRESS: phases
+   A+B landed (cols threaded, netlist byte-identical at 4), phase C
+   fully scoped in _notes/wider-well.md (five emitters; check tables
+   verified against three hand-laid trees; contact-allocator API +
+   the extracted set-spend ledger). next session: implement the
+   allocator, then the step-tree emitter.
 
 ## display/input notes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -567,8 +567,37 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    file + check + playwright hands-off scenario green. the scratch
    experiment that gated the design: the first stepTime run ever to
    drive the game (nothing in the browser had called it before).
-   NEXT: deploy the two pending arcs as receipts land; then the canvas
-   multivac viewer or column scaling (a wider well).
+   THE MACHINE WALL + THE OSCILLATOR GAPS (3b-6) LANDED 2026-08-20, same
+   session: the canvas viewer rung — a strip under the well drawing ALL
+   104 minivacs (12-row build) as tiles, six armature dots each, amber
+   when energized, redrawn straight from getMachineState on every render
+   (no react, no per-frame state). the wall's FIRST driver run caught a
+   real bug, which unspooled into the arc's two operating hazards, both
+   machine-verified and now pinned by a contract test: (1) a START
+   pressed while TDRV holds the tick line high DISSIPATES — the arm
+   needs a low line to survive to the next rising edge; under stepTime
+   the cycle settles tick-low only on the buzz solve (~1 beat in 5), so
+   Enter under auto lost ~4 of 5 spawns, silently. (2) taking the AUTO
+   slide back mid-release FREEZES the line high (time stops, the cap
+   never drains) — every manual tick and START is dead against it: the
+   page's old 'a'-off wedged the whole machine, which is exactly what
+   the wall receipt tripped on (tick with zero relay change = frozen
+   bitmap). fixes are operator guards, same philosophy as the enter
+   interlock: Enter under auto waits for a beat that settled tick-low
+   and re-presses if the machine still swallowed it; 'a'-off cuts the
+   feed FIRST, keeps time flowing until the driver relay stays down
+   (the cap drains through the coil in a couple of beats), and only
+   then stops the clock; 'a' is allowed through the game-over freeze
+   (gravity must always be stoppable). steering needed nothing —
+   level-read, not edge-consumed (verified). also observed, still
+   unexplained: transient 5.3A short prints during buzz-adjacent event
+   solves (console only, never in settled alerts). receipts: the
+   five-part oscillator-gaps machine test, guarded spawn + hands-off
+   fall + breathing wall + post-drain manual play all asserted by the
+   driver, file/check green. no circuit changes (page + tests only).
+   NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
+   overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
+   batch); then column scaling (a wider well).
 
 ## display/input notes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -595,14 +595,35 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    five-part oscillator-gaps machine test, guarded spawn + hands-off
    fall + breathing wall + post-drain manual play all asserted by the
    driver, file/check green. no circuit changes (page + tests only).
-   NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
-   overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
-   batch); then column scaling (a wider well) — IN PROGRESS: phases
-   A+B landed (cols threaded, netlist byte-identical at 4), phase C
-   fully scoped in _notes/wider-well.md (five emitters; check tables
-   verified against three hand-laid trees; contact-allocator API +
-   the extracted set-spend ledger). next session: implement the
-   allocator, then the step-tree emitter.
+   GRAVITY CORRECTED 2026-08-20 (user report: 4-5 row skips, phantom
+   shapes): the oscillator-as-game-clock was WRONG under the sim's
+   relaxation semantics. established by experiment (a follower relay
+   and a two-cap cross-coupled astable both reproduced the identical
+   trail): a self-oscillating pair's transition relaxations flutter —
+   the cap companion is a soft resistor at game dt — and EVERY
+   flutter cycle reaches the ring as a real tick edge, 3-4 rows in
+   one solve; no relay topology escapes, because the quasi-static
+   solver compresses the transition dynamics into one solve. the
+   "phantom shapes" were the machine's own respawn re-arm doing its
+   job at burst speed. fix: auto-gravity now cycles the TICK SLIDE
+   on a timer (operator cadence, 700ms) — the exact single-step path
+   manual play uses; the oscillator stays as a parity-exact physics
+   demo, and the page's tick-low spawn guard + drain dance died with
+   it. NEW RECEIPTS, user-shaped: the driver asserts NO fall ever
+   advances more than one row between samples, and a STEP-EXACT
+   scripted game checks the full 12x4 pixel grid against a rules
+   model after EVERY keypress — three pieces, steering, a line
+   clear, the collapse, the post-clear respawn. the harness caught
+   the merged land+lock semantics on its first run. deploy-gate
+   policy (user call): fast suite + the 5000-circuit dense-vs-fast
+   sweep per deploy; the 47-min dense scenario becomes an occasional
+   overnight receipt (zero engine disagreements ever, ~1e-10 mA max).
+   WIDER WELL in progress: A+B landed byte-identical; the allocator,
+   the step-tree emitter and the FAN emitters landed behaviorally
+   green at 4 (file 32); the UP-transition emitter remains, then the
+   cols=6 flip.
+   NEXT: deploy gravity + wider-well prep on the sweep receipt; then
+   the UP-transition emitter and cols=6.
 
 ## display/input notes
 

--- a/_notes/tetris-roadmap.md
+++ b/_notes/tetris-roadmap.md
@@ -545,9 +545,30 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    pos mirrors as two-hot-at-boot). receipts: the 12-state walk, L2+J2
    locks stacked on each other's stems, T2 steering refused-then-allowed
    under a tower, file/check/playwright green. 502 relays / 85 machines.
-   NEXT: deploy the whole ring arc once the restructured receipts land;
-   then the ladder's next rungs — the canvas multivac viewer, column
-   scaling (a wider well), or capacitor-timed self-ticking.
+   THE MACHINE TICKS ITSELF (3b-5) LANDED 2026-08-20, same session:
+   CAPACITOR GRAVITY. a two-relay slow-release oscillator on the REAL
+   capacitor bank — TOSC's coil parallels four paralleled 500uF sections
+   and is fed through TDRV's NC; TDRV follows TOSC and its second set
+   bridges + onto the tick net exactly as the tick slide's closure does
+   (the compatibility-OR again — the slide stays live). under stepTime:
+   the supply recharges the bank in ONE backward-euler step (A-stable,
+   no overshoot), the pair latches tick-HIGH while the bank drains
+   through the 55-ohm coil (~hundreds of ms), and the dropout transition
+   BUZZES — a real relay oscillator buzzes; the chatter pins de-energized
+   (the device-verified book-IV class) leaving one clean tick-LOW step,
+   then the cycle repeats. AUTO = the slide on TOSC's own section; the
+   two relays landed exactly in m83's last two free sections (504 relays,
+   still 85 machines). the page's 'a' key opens the time faucet (an
+   interval feeding wall-clock dt into stepTime) — the OSCILLATOR does
+   all the ticking, lock bookkeeping included; steering and reshaping
+   keep working mid-fall. receipts: engine parity on the oscillator
+   (sparse and fast agree edge-for-edge and cap-voltage-exact), hands-off
+   gameplay from a single START press, AUTO-off freezes gravity, whole
+   file + check + playwright hands-off scenario green. the scratch
+   experiment that gated the design: the first stepTime run ever to
+   drive the game (nothing in the browser had called it before).
+   NEXT: deploy the two pending arcs as receipts land; then the canvas
+   multivac viewer or column scaling (a wider well).
 
 ## display/input notes
 

--- a/_notes/tetris-roadmap.md
+++ b/_notes/tetris-roadmap.md
@@ -597,7 +597,12 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    driver, file/check green. no circuit changes (page + tests only).
    NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
    overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
-   batch); then column scaling (a wider well).
+   batch); then column scaling (a wider well) — IN PROGRESS: phases
+   A+B landed (cols threaded, netlist byte-identical at 4), phase C
+   fully scoped in _notes/wider-well.md (five emitters; check tables
+   verified against three hand-laid trees; contact-allocator API +
+   the extracted set-spend ledger). next session: implement the
+   allocator, then the step-tree emitter.
 
 ## display/input notes
 

--- a/_notes/tetris-roadmap.md
+++ b/_notes/tetris-roadmap.md
@@ -567,8 +567,37 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    file + check + playwright hands-off scenario green. the scratch
    experiment that gated the design: the first stepTime run ever to
    drive the game (nothing in the browser had called it before).
-   NEXT: deploy the two pending arcs as receipts land; then the canvas
-   multivac viewer or column scaling (a wider well).
+   THE MACHINE WALL + THE OSCILLATOR GAPS (3b-6) LANDED 2026-08-20, same
+   session: the canvas viewer rung — a strip under the well drawing ALL
+   104 minivacs (12-row build) as tiles, six armature dots each, amber
+   when energized, redrawn straight from getMachineState on every render
+   (no react, no per-frame state). the wall's FIRST driver run caught a
+   real bug, which unspooled into the arc's two operating hazards, both
+   machine-verified and now pinned by a contract test: (1) a START
+   pressed while TDRV holds the tick line high DISSIPATES — the arm
+   needs a low line to survive to the next rising edge; under stepTime
+   the cycle settles tick-low only on the buzz solve (~1 beat in 5), so
+   Enter under auto lost ~4 of 5 spawns, silently. (2) taking the AUTO
+   slide back mid-release FREEZES the line high (time stops, the cap
+   never drains) — every manual tick and START is dead against it: the
+   page's old 'a'-off wedged the whole machine, which is exactly what
+   the wall receipt tripped on (tick with zero relay change = frozen
+   bitmap). fixes are operator guards, same philosophy as the enter
+   interlock: Enter under auto waits for a beat that settled tick-low
+   and re-presses if the machine still swallowed it; 'a'-off cuts the
+   feed FIRST, keeps time flowing until the driver relay stays down
+   (the cap drains through the coil in a couple of beats), and only
+   then stops the clock; 'a' is allowed through the game-over freeze
+   (gravity must always be stoppable). steering needed nothing —
+   level-read, not edge-consumed (verified). also observed, still
+   unexplained: transient 5.3A short prints during buzz-adjacent event
+   solves (console only, never in settled alerts). receipts: the
+   five-part oscillator-gaps machine test, guarded spawn + hands-off
+   fall + breathing wall + post-drain manual play all asserted by the
+   driver, file/check green. no circuit changes (page + tests only).
+   NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
+   overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
+   batch); then column scaling (a wider well).
 
 ## display/input notes
 

--- a/_notes/tetris-roadmap.md
+++ b/_notes/tetris-roadmap.md
@@ -595,14 +595,35 @@ GAME OVER LANDED 2026-08-20, same session: a lock at row 0 latches
    five-part oscillator-gaps machine test, guarded spawn + hands-off
    fall + breathing wall + post-drain manual play all asserted by the
    driver, file/check green. no circuit changes (page + tests only).
-   NEXT: deploy the pending arcs as receipts land (4a0aa1e = the
-   overhang trio, DEPLOYED this session; 3b-5/3b-6 ride the next
-   batch); then column scaling (a wider well) — IN PROGRESS: phases
-   A+B landed (cols threaded, netlist byte-identical at 4), phase C
-   fully scoped in _notes/wider-well.md (five emitters; check tables
-   verified against three hand-laid trees; contact-allocator API +
-   the extracted set-spend ledger). next session: implement the
-   allocator, then the step-tree emitter.
+   GRAVITY CORRECTED 2026-08-20 (user report: 4-5 row skips, phantom
+   shapes): the oscillator-as-game-clock was WRONG under the sim's
+   relaxation semantics. established by experiment (a follower relay
+   and a two-cap cross-coupled astable both reproduced the identical
+   trail): a self-oscillating pair's transition relaxations flutter —
+   the cap companion is a soft resistor at game dt — and EVERY
+   flutter cycle reaches the ring as a real tick edge, 3-4 rows in
+   one solve; no relay topology escapes, because the quasi-static
+   solver compresses the transition dynamics into one solve. the
+   "phantom shapes" were the machine's own respawn re-arm doing its
+   job at burst speed. fix: auto-gravity now cycles the TICK SLIDE
+   on a timer (operator cadence, 700ms) — the exact single-step path
+   manual play uses; the oscillator stays as a parity-exact physics
+   demo, and the page's tick-low spawn guard + drain dance died with
+   it. NEW RECEIPTS, user-shaped: the driver asserts NO fall ever
+   advances more than one row between samples, and a STEP-EXACT
+   scripted game checks the full 12x4 pixel grid against a rules
+   model after EVERY keypress — three pieces, steering, a line
+   clear, the collapse, the post-clear respawn. the harness caught
+   the merged land+lock semantics on its first run. deploy-gate
+   policy (user call): fast suite + the 5000-circuit dense-vs-fast
+   sweep per deploy; the 47-min dense scenario becomes an occasional
+   overnight receipt (zero engine disagreements ever, ~1e-10 mA max).
+   WIDER WELL in progress: A+B landed byte-identical; the allocator,
+   the step-tree emitter and the FAN emitters landed behaviorally
+   green at 4 (file 32); the UP-transition emitter remains, then the
+   cols=6 flip.
+   NEXT: deploy gravity + wider-well prep on the sweep receipt; then
+   the UP-transition emitter and cols=6.
 
 ## display/input notes
 

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -367,6 +367,27 @@ overhang fans (3b-4c section), + their pos-mirror class maps.
 the UP-TRANSITION emitter (the other fence-holder) comes after; its
 delta-check structure reuses the same pos banks.
 
+## the UP-transition emitter, spec (16:55Z — surveyed 2038-2110+)
+
+structure per transition into-i: MMIR(i) contact (root chain off UPM)
+-> a one-hot POS fan (pos mirrors chained) -> per-pos branch = SERIES
+delta reads on the occupancy rails -> join -> the clock com. a missing
+branch IS the bound refusal (nothing conducts; the ring holds). the
+reads are PLAIN rail copies (LEGB/UTR-class, coil parallel to the
+rail) — NO union gates needed: the one-hot pos fan already scopes each
+branch to exactly one (state-pair, pos).
+EMITTER: reshapeEntering(s1, s2, p) = B(s2,p)\B(s1,p) and T(s2,p)\
+T(s1,p) from the geometry (clip at the well edges); emit a branch for
+every p where both footprints fit; resources = a per-pos mirror bank
+(SHARED with the fan emitter) + plain-read pools per rail column +
+the join chain into the clock com. the wrap (11 -> 0) is just another
+pair. replaces: MMIR/POSM4/POSM5/POSM6 class maps, LEGB2/UTR/UTR2/
+UTR3 read banks, and the three per-era transition blocks.
+
+ORDER for the next stretches: fan emitter first (its offset rails are
+the step-tree unions' siblings), then the UP emitter (reuses the pos
+banks), then the fence lifts: cols=6 tests + page bump + receipts.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -293,6 +293,31 @@ bound mirrors + ret groups (counted, generous caps, assert spent<=cap).
 freed banks stay claimed-but-unwired (dead index space, zero netlist
 cost; compaction later).
 
+## step-tree emitter, final spec (audit resolved, 15:55Z)
+
+- LEGB seam RESOLVED: LEGINV2 coils are parallel copies on the SAME
+  rail nets, so all four LEGB feeds re-home to LEGINV(j).E (2-hole
+  budgets fit once LEGINV2 dies). LEGB + its UP-network consumers
+  survive untouched.
+- per-tree chain ORDER: bound refusals FIRST, then the gated reads,
+  then the step (a refused state must never reach a read that would
+  index out of the well).
+- reads CLIP: a read at column c+d with c+d outside [0, cols) is
+  skipped — every member state is bound-refused before it anyway.
+- d0-top reads REUSE LEGINVT(c) (coil re-wired PLAIN — the ZG NOT-gate
+  dies; the T0/T0L union contacts gate the sample path instead). d0-
+  bottom reuses LEGINV(c) the same way (gates in the path, coil as-is).
+- union rails (10): B0{1x1,2tall,J2} B1{2wide,O,S,Z,T2} B2{L,J,T,L2}
+  T0{2tall,S,L1} T1{O,T1} T2{Z,J1,L2,J2,T2} T0L{2tall,O,L1,L2,J2,T2}
+  T1L{Z,T1} HIB{Z,L,J,T,L2,J2,T2} WALLB{2wide,O,S}; left singletons
+  S(top c-1), J1(top c+2), T2(bottom c+1, changeover: NC chains the
+  left-d0 gate), L2(bottom c+2, changeover ditto).
+- counts at 4: pool reads 18, union rails 10, union-gate mirrors ~25,
+  state-member mirrors ~24 -> tail ~106 relays (+18 machines at 8
+  rows) while ~35 die unwired. uniformity costs ~3x the hand's tree
+  relays; accepted (tick +~20%, more armatures on the wall).
+- ret taps: ~6/tree; count exactly while emitting, assert <= cap.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -232,6 +232,19 @@ bounds and transitions all derive from the SHAPES tuple; the allocator
 owns every resource map. that closes the phase C design — remaining
 work is implementation.
 
+## prerequisite before the emitters: flip the constant direction
+
+the C emitters change bank SIZES at cols=4 (minimal checks drop the
+belt-and-braces relays), which shifts every baked constant after the
+first changed bank — the eq() gates would throw at module load. so
+BEFORE any emitter lands: make tetrisLayout primary and DERIVE the
+exported constants (`const L8 = tetrisLayout(8); export const SHR =
+L8.SHR; ...`), delete the eq() block (tautological then), keep the
+claim registry (it guards overlaps on the derived values). consumers
+(TETRIS_IO, the test file) import names/functions, never hard numbers
+— safe. gates: netlist byte-identity + tsc + fast file. bounded
+(~250 lines of mechanical rewiring), do it as its own commit.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -137,6 +137,39 @@ size estimate: a full rung arc (comparable to all of 3b). the gate per
 emitter: behavior at 4 (file + check + driver + the dense batch), then
 the width flip to 6 with new-edge tests.
 
+## the contact allocator, first API sketch (pre-code)
+
+data model:
+- a SOURCE is a coil net that mirrors chain onto: a ring slave (state),
+  a POSS slave (pos), a mode relay (WIDM/VMODE/STAG/WID3/TT/BCUT...).
+- request(source, kind) -> a fresh contact set handle {relay, set1|2},
+  minting a new mirror on the source's coil chain when all existing
+  sets of that source's mirrors are spent. kind is 'changeover' (arm +
+  both throws reserved) or 'gate' (arm + one throw; the OTHER throw of
+  that set stays claimable by a later 'gate' on the SAME source only if
+  electrically legal — default NO, the tie-point law: one consumer per
+  set unless the second is a proven one-hot-safe join).
+- the allocator EMITS the mirror coil wires itself (chain at the coil
+  jacks, F -> minus) and returns jack names via R(relay, ...).
+- every mint is claim()-registered; layout counts stop being hand-laid
+  take() literals for these banks and become the allocator's tally,
+  asserted == the take() size (the take sizes then derive from a dry
+  ALLOCATION PASS: run the emitters' request stream once to count, then
+  lay out — two-pass build, same shape as the existing grown() logic).
+- ordering: mints must be deterministic (stable request order) so the
+  netlist is reproducible run to run.
+
+open questions for the next session:
+- do the emitters run inside tetrisLayout (counts) AND tetrisCircuit
+  (wires) — or does tetrisCircuit compute the whole thing and hand the
+  layout back? leaning: a single build function that returns both, with
+  tetrisLayout(rows, cols) becoming a thin wrapper that runs the count
+  pass only (keeps the exported baked constants + eq gates intact).
+- jack-hole budgets: request() must also track the 2-holes-per-jack
+  spend on the THROW side when consumers chain at output jacks (the
+  LEGB-output-tie pattern) — probably a second primitive join(handleA,
+  handleB) that validates capacity.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -89,6 +89,26 @@ reshape (ring step s1->s2 at pos p): check B2(p)\B1(p) and T2(p)\T1(p)
 plus the bound clamp — exactly what the UP transition network wires
 today as one-hot pos fans + series delta hops.
 
+## the check tables (scratchpad/check-table.mjs; VERIFIED against the
+## hand-laid trees on three states: S p1R, Z p0R + the NOT-Z gate, and
+## the narrow single-column checks — formula reproduces the wiring)
+
+at any cols, stepping RIGHT into target c checks rails at fixed offsets
+from c per state: b = c + bOff + bW - 1, t = c + tOff + tW - 1 (tW>0);
+LEFT into c: b = c + bOff, t = c + tOff. the tables are shift-invariant
+across the interior — one pattern per state per direction, bounds at the
+range edges. offsets (db, dt) per state, RIGHT:
+1x1 (0,-)  2wide (1,-)  2tall (0,0)  O (1,1)  S (1,0)  Z (1,2)
+L (2,0)  J (2,2)  T (2,1)  L2 (2,2)  J2 (0,2)  T2 (1,2)
+emitter shape = the existing trunk generalized: shared bottom check at
+c+0 -> tall fork -> shared top at c+0 -> wide fork -> b at c+1 -> tall-
+wide t at c+1, with state-gated series hops for every staggered delta
+(c+2 reads and the asymmetric combos), and bound refusals as state-
+mirror contacts where c is outside the state's range. the resource half:
+reads at c+2 (and repeated reads per column) need parallel-coil rail
+copies where a relay's two contact sets run out — the LEGINV2 pattern,
+allocated per column by CONSUMER COUNT, not hand-laid.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -407,6 +407,26 @@ ORDER for the next stretches: fan emitter first (its offset rails are
 the step-tree unions' siblings), then the UP emitter (reuses the pos
 banks), then the fence lifts: cols=6 tests + page bump + receipts.
 
+UP emitter resource plan (17:35Z, concrete):
+- branches: for i in 0..11, s2=(i+1)%12, for p in range(s1) AND
+  range(s2): emit; a p missing from range(s2) simply has no branch =
+  the bound refusal, exactly the hand's semantics (the page clamps
+  first as operator kindness — unchanged).
+- deltas: reshapeEntering(s1,s2,p) = bottom/top cells of s2-at-p minus
+  s1-at-p, clipped to the well; bottom deltas read the occupancy rails,
+  top deltas the top rails, both as PLAIN copies (no union gates — the
+  one-hot pos fan already scopes each branch).
+- resources: UPPOS bank take(5*cols) (pos fan sets, ~10 uses/pos);
+  UPREAD plain-read pool (coil fed straight from legTap/legTTap holes
+  — the tap() hole allocator budgets the rail groups, same as the
+  trees' gated reads); MMIR/MMIR2/MMIR3 master mirrors stay; the root
+  chain over the 12 M arms stays; branch ends chain into the ring
+  clock com as today.
+- replaces: POSM4/POSM5/POSM6 class maps, LEGB2/UTR/UTR2/UTR3 banks,
+  the three per-era transition blocks (~90 wires).
+- estimate: ~45-50 relays at cols=4 (the hand spent ~35; the pools
+  over-allocate and a later shrink pass can tighten).
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -246,6 +246,53 @@ claim registry (it guards overlaps on the derived values). consumers
 — safe. gates: netlist byte-identity + tsc + fast file. bounded
 (~250 lines of mechanical rewiring), do it as its own commit.
 
+## the step-tree emitter: design settled, extraction inventory (15:45Z)
+
+DESIGN DECISION — the uniform union-gated tree: no mode forks. every
+check in a tree is a union-gated rail read in series; a dead union's NC
+passes the sample through (the LTS pattern generalized to everything).
+per tree (target c, direction d), from stepEntering():
+- group the 12 states by their checked-column OFFSET per row: e.g.
+  RIGHT bottom: d0 {1x1, 2tall, J2}, d1 {2wide, O, S, Z, T2},
+  d2 {L, J, T, L2}; RIGHT top: d0 {2tall, S, L1}, d1 {O, T1},
+  d2 {Z, J1, L2, J2, T2}. LEFT bottom: d0 {all but T2 (d1), L2 (d2)};
+  LEFT top: d-1 {S}, d0 {2tall, O, L1, L2, J2, T2}, d1 {Z, T1}, d2 {J1}.
+- one UNION RAIL per group (wired-OR of state-mirror contacts, the
+  ZJT/SLJ/TT pattern), one GatedReadPool read per (tree, group) at
+  rail column c+d, all in series, then the step. d0-bottom reuses the
+  existing LEGINV(c) changeover (both sets: right tree set1, left set2).
+- bounds are width-invariant: RIGHT tree at c = cols-2 refuses the
+  max==cols-3 group {Z, triples, overhangs} (three group contacts);
+  the wall tree (c = cols-1) refuses the WIDM-class {2wide, O, S}
+  (max==cols-2; Z/triples/overhangs can't SIT at cols-2, one-hot);
+  LEFT tree at c=0 refuses S (min 1). nothing else, at any width.
+- relay cost at 6: ~55 reads + ~6 unions + member mirror sets; the
+  hand's fork optimization is dropped for uniformity (more armatures
+  for the wall, mechanical derivation, behavioral gate).
+
+EXTRACTION INVENTORY (what the surgery touches — five sites):
+1. the D-tap section (the trees proper, ~1563-1755).
+2. 3b-3b coils: SG/ZG mirrors + LTS/LTZ gated coils (~2079-2092) —
+   tree-only, dies with the trees (ZG(0,1)/SG(0) NOT-gates die too:
+   the uniform tree has no shared-check gates).
+3. 3b-4b: ZJT/SLJ unions + LTJ/LTT/LTB3 gated coils — ZJT/SLJ die
+   (their gates die); LTJ/LTT/LTB3 die (reads re-minted from the pool).
+4. 3b-4c: LTOT/LTOB/T2B gated coils die; BCUT/BCUTM (the OVR bypasses)
+   DIE ENTIRELY — the uniform tree has no false-refusing shared bottom
+   check to bypass (d0 reads are gated on the d0 union, which excludes
+   L2/T2 on the right). TT/TTM survive (transition network + rails).
+5. SHARED SEAMS that must survive unchanged: SM/ZM mirror sets feeding
+   the T fan + WIDB rail; TRPM(0) rail feeds; TTM rail/transition sets;
+   the LEGB occupancy-term feeds — today they chain off LEGINV(0)/(1)
+   and LEGINV2(2)/(3) COIL jacks; LEGINV2 dies with the trees (the
+   wide-fork copies), so the LEGB feeds for columns 2..3 must re-home
+   to emitter-minted d1-read coils or their own rail taps. AUDIT THIS
+   ONE FIRST when wiring.
+new layout tail: union bank + state-mirror growth + GatedReadPool +
+bound mirrors + ret groups (counted, generous caps, assert spent<=cap).
+freed banks stay claimed-but-unwired (dead index space, zero netlist
+cost; compaction later).
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -232,7 +232,8 @@ bounds and transitions all derive from the SHAPES tuple; the allocator
 owns every resource map. that closes the phase C design — remaining
 work is implementation.
 
-## prerequisite before the emitters: flip the constant direction
+## prerequisite before the emitters: flip the constant direction — DONE
+## (6a4a507: 151 exports derive from L8, eq block deleted, gates green)
 
 the C emitters change bank SIZES at cols=4 (minimal checks drop the
 belt-and-braces relays), which shifts every baked constant after the

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -182,6 +182,23 @@ at cols=4 must land within these counts (equal or tighter). the script
 doubles as the C gate's cross-check: run it on the emitted netlist and
 diff the spend per source family.
 
+## gate tooling
+
+- byte gate: scratchpad/dump-netlist.mjs (exact list order) — held for
+  phases A+B.
+- SET gate: scratchpad/dump-netlist-sorted.mjs (endpoints normalized,
+  list sorted, duplicates kept = multiset) — two dumps equal iff the
+  circuits are electrically identical regardless of push order. this is
+  the gate for allocator conversions (MirrorBank emits coil wires
+  lazily, so positions shift while the wire multiset must not).
+- spend gate: scratchpad/contact-ledger.mjs — per-set usage diff.
+- emitter 0 (MirrorBank, src/circuits/contact-alloc.ts) is LANDED and
+  unit-tested, not yet wired in. pilot conversion target: VMODEM (its
+  8 sets are spent in natural tree order — right-1 s1+s2, right-2
+  s1+s2, wall s1, left-0 s2, left-1 s1... wait: left-1 and left-2 ride
+  VMODEM(3); left-0 rides VMODEM(2).set2 — request order in tree order
+  reproduces the hand map exactly, so the SET gate must hold).
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -1,0 +1,65 @@
+# the wider well (column scaling) — scoping notes, 2026-08-20
+
+second parameterization axis. rows landed earlier (ctor arg, grown()
+groups, claim registry + eq gates); cols is baked at 4 in ~50 generator
+sites plus the test file and the page. same medicine.
+
+## per-column subsystem inventory (what scales)
+
+- CELL(r,j): rows relays per column (the field).
+- W(r,k): the write groups — one write coil per row PER COLUMN.
+- LINE(j), PIECE(j), PIECET(j): line-full + bottom/top piece gates.
+- POSA/POSS/POSM(j): the position register one-hots + edge no-op wiring.
+- PRESSCUT(x)/P2CUT(x): per-column collision-mirror cuts.
+- LEGINV/LEGINVT/LEGB(j) (+LEGB2/LEGB3 col classes): legality trees.
+- POSM4/POSM5/POSM6: pos-CLASS mirrors — these encode SPECIFIC columns
+  (edges, interior boundaries for bounds). the class map is a function
+  of cols and must be DERIVED, not copied.
+- bound contacts per ring state (SBND/ZBND/TRPBND/TTBND + the wrap
+  check): which pos refuses which state moves with cols. the page
+  already computes min/maxPos from SHAPES geometry:
+    minPos = max(0, -bOff, -tOff)
+    maxPos = min(c - bOff - bW, tW>0 ? c - tOff - tW : c - 1)
+  the generator must emit the refusing contacts from the SAME formulas.
+- M10/M11 rail groups: more columns = more taps/groups; budget grows
+  with machine count, assertJackCapacity + the claim registry enforce.
+- cols-independent: the shape ring itself (12 states), the score ring,
+  the oscillator, the collapse row-walk (walks rows, reads all cols via
+  the per-column machinery above).
+
+## growth model (rows=12)
+
+per added column ≈ CELL 12 + W 12 + LINE/PIECE/PIECET 3 + POS* 3 +
+cuts 2 + trees ~3 + mirror shares ~2 ≈ ~37 relays ≈ 6.2 machines.
+4 -> 6 cols: ~+75 relays, ~+13 machines (605/104 -> ~680/~117 at 12
+rows). wall canvas auto-scales. page tick cost +~13% — fine.
+
+## plan (each phase gated, committed separately)
+
+- A: thread cols through tetrisLayout + claim registry + eq checks.
+  GATE: netlist byte-identical at (8,4) (diff the sorted wire list
+  before/after — the strongest refactor receipt).
+- B: per-column loops take cols (fans, registers, trees, cuts, writes).
+  GATE: still byte-identical at (8,4).
+- C: column-CLASS sites re-derived from cols (POSM4/5/6 class maps,
+  per-state bound contacts from the geometry formulas, edge no-ops).
+  GATE: byte-identical at (8,4) — every hand-laid class must fall out
+  of the formula at c=4 exactly, or the formula is wrong.
+- D: cols=6 behavior: walk test at 6, steering/locks at columns 4-5,
+  bounds at the new right edge, page COLS=6 + driver, receipts
+  (fast file, check, playwright), then the dense scenario batch
+  before any deploy.
+
+increment decision: parameterize fully, bump the page 4 -> 6 (5 feels
+cramped for the staggered family; 10 is the endpoint once perf at 6 is
+measured).
+
+## traps to respect (from the rows job + 3b)
+
+- a borrowed contact set is free only if arm AND throws are unwired.
+- ret-group counts must include the tree's own refusals.
+- every ring accessor must know all index blocks (the 2-way/3-way bug
+  shipped twice).
+- one-hot sources make shared-net fan-outs legal; everything else is
+  the tie-point law.
+- jack capacities are real: 2/jack, 4/COM, 6/M10-M11.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -54,6 +54,41 @@ increment decision: parameterize fully, bump the page 4 -> 6 (5 feels
 cramped for the staggered family; 10 is the endpoint once perf at 6 is
 measured).
 
+## phase C framework (from reading the D-tap trees, 14:30Z)
+
+step legality for a piece at pos p stepping to q = p+-1, token row r,
+geometry (bOff, bW, tOff, tW):
+- B(x) = {x+bOff .. x+bOff+bW-1} clipped to [0, cols); T(x) likewise
+  with tOff/tW at row r-1.
+- stored content can never coexist at the piece's OWN cells (gravity +
+  entry checks), so checking T(q) whole equals checking the delta —
+  the hand-laid trees mix both styles and carry some provably-redundant
+  hops ("belt and braces", wired historically).
+- bounds: q in [minPos, maxPos] from the geometry formulas; the trees
+  refuse via state-mirror contacts where q is out of range.
+- the current 4-col instantiation: shared bottom check LEGINV(entering
+  col), VMODEM tall fork -> LEGINVT, WIDM3/4 wide fork -> LEGINV2(c+1),
+  then per-state gated hops in series (LTS/LTZ/LTJ/LTT/LTB3/LTOT/LTOB/
+  T2B), each dead-mode NC passing through. refusals return via retNode
+  taps into the current master's coil.
+
+IMPORTANT GATE CHANGE for C: a geometry-driven tree emitter emits the
+MINIMAL correct checks, so the 4-col netlist will legitimately differ
+from the hand-laid one (redundant hops dropped, tap orders shift).
+phase C's gate is therefore NOT byte identity — it is the full
+behavioral bar: whole fast file + check + playwright at 4, the dense
+8-row scenario + sweep batch, all green BEFORE the width ever changes;
+then the same bar again at 6. (A+B keep their byte-identity receipt.)
+
+## per-state entering sets (derive the emitter from these)
+
+with SHAPES geometry (label, bOff, bW, tOff, tW), stepping RIGHT p->q=p+1
+enters bottom {q+bOff+bW-1} and top {q+tOff+tW-1} (tW>0); LEFT p->q=p-1
+enters bottom {q+bOff} and top {q+tOff}. checks clip out of range.
+reshape (ring step s1->s2 at pos p): check B2(p)\B1(p) and T2(p)\T1(p)
+plus the bound clamp — exactly what the UP transition network wires
+today as one-hot pos fans + series delta hops.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -318,6 +318,29 @@ cost; compaction later).
   relays; accepted (tick +~20%, more armatures on the wall).
 - ret taps: ~6/tree; count exactly while emitting, assert <= cap.
 
+## the step trees are EMITTED (16:05Z, landing in progress)
+
+the uniform union-gated emitter replaced the hand-laid D-tap section:
+ten union rails + per-state mirror banks (chained off each state's
+EXISTING mirror-chain tails — the slave coil jacks were full), the
+gated read pool, per-source ret groups (4 each — ~15 refusal taps
+peak, width-invariant), pending-output coalescing before the master
+coms (their budgets are exactly coil + hold + self-loop + step).
+retired: LEGINV2/LEGINVT2/VMODEM-contacts/WIDM3-4-contacts/SG-ZG NOT
+gates/LTS/LTZ/LTJ/LTT/LTB3/LTOT/LTOB/T2B (+their rail taps freed);
+the VMODEM coil chain stays wired (it IS the tall compatibility-OR
+splice point), WIDM3/4 coils stay (the WIDB splice rides them).
+iteration bugs the capacity asserts caught, in order: L2/T2 mirror
+caps undercounted the per-tree spends; POSA com overflow (fixed by
+coalescing); slave-E overflow (fixed by tail-chaining); ret groups
+ran dry at 3 (grown to 4).
+growth: 8-row 499 -> 627 relays (85 -> 107 machines), 12-row 605 ->
+733 (104 -> 125), dead banks included.
+receipts so far: walk test green, all steering tests green including
+seeded random gameplay; full file + check + driver pending, then the
+dense batch before any deploy. the fence (cols !== 4) STAYS until the
+fan + transition emitters land.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -344,6 +344,29 @@ the dense batch on the emitter tip is running; its green gates the
 deploy. the fence (cols !== 4) STAYS until the fan + transition
 emitters land — those are the next work units.
 
+## the fan emitters, spec (16:45Z — next surgery)
+
+the hand's B fan IS an offset-rail factorization already: per offset d,
+a rail = union of states whose bottom span covers d, and per column j a
+series tap (pos p=j-d AND rail-d) into PIECE(j).E:
+- d0 = base (bOff=0 states; BCUT suppresses it for L2/T2 — i.e. the d0
+  rail is really the union WITHOUT offset-bottom states),
+- d1 = the WIDM net (2wide|O|S|Z|T2 + the slide splice — EXACTLY the
+  step trees' B1 union),
+- d2 = the WID3 net (TRP=L,J,T + L2).
+the T fan factorizes identically with tOff/tW: rails T-1 {S}, T0, T1,
+T2 over the pos taps into PIECET(j).E.
+EMITTER: reuse the union machinery — offset rails (slide legacy pairs
+included via the existing WIDM/VMODE compatibility nets), a per-
+position mirror bank (replacing the hand POSM2/POSM3/POSM5/POSM6 class
+maps), and a loop emitting (posMirror AND railMirror) series pairs per
+column, chained at output jacks into each coil net's one free hole.
+sites to replace: the base/WIDM/WID3 taps (~1454, 1488-90, 2190-91),
+the S/Z T fan (2005-2017), the triples' T fan (2192-2202), the TT/
+overhang fans (3b-4c section), + their pos-mirror class maps.
+the UP-TRANSITION emitter (the other fence-holder) comes after; its
+delta-check structure reuses the same pos banks.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -367,6 +367,25 @@ overhang fans (3b-4c section), + their pos-mirror class maps.
 the UP-TRANSITION emitter (the other fence-holder) comes after; its
 delta-check structure reuses the same pos banks.
 
+## the fan emitters LANDED (bring-up log, 16:56Z)
+
+B fan: base = BCUT.NC -> chained POSS arms -> K outputs into PIECE(j).E
+(cols-general); wide/third taps mint from banks fed THROUGH the retired
+fork relays' freed sets (WIDM4.set1 -> FANWIDM, WID3M.set1 -> FANWID3 —
+the WIDM/WID3M coil nets are hole-saturated by slide feeds + splices,
+so parallel-coiling could not enter). T fan: four offset rails with the
+STAGGER predicate (top != bottom footprint — symmetric states write
+phase 2 through the B fan; that predicate was bring-up bug #4), rail-
+mirror x pos-mirror private pairs per column, outputs chained into
+PIECET(j).E's one hole. FANPOS(0) feeds through POSM2(0)'s freed set2
+(pos 0's slave E carries the home set); FANPOS(1..) parallel POSS(p).E.
+bring-up bugs the asserts caught: a silent no-op python replace left
+old caps live (VERIFY REPLACES — assert the target exists); POSS(0).E
+home-set hole; WIDM net saturation; POSM2 chain saturation; the
+stagger predicate; the deleted base outputs (walk caught cols 1,2 lit
+and col 0 dark). walk + all lock (7) + staggered (3) green; full file
+running.
+
 ## the UP-transition emitter, spec (16:55Z — surveyed 2038-2110+)
 
 structure per transition into-i: MMIR(i) contact (root chain off UPM)

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -215,6 +215,23 @@ table's (db,dt) offsets + bounds, requesting sets from MirrorBanks,
 first reproducing behavior at cols=4 (suite + driver + dense batch),
 then unlocking 5/6.
 
+## mode rails are geometry predicates (design closed, 15:00Z)
+
+verified against the wiring (2028-2092 + the splices): every mode rail
+is a predicate over SHAPES, wired as a one-contact-per-state OR chain
+into the coil net (the LEGB trick — each coil net takes ONE wire):
+- WIDM  (wide fork)      = bW == 2   -> 2wide, O, S, Z
+- WID3  (third column)   = bW == 3   -> L, J, T (the TRP rail)
+- tall  (VMODEM union)   = tW > 0    -> everything but 1x1/2wide
+- STAG  (phase-2 T fan)  = top footprint != bottom footprint
+                           -> S, Z, triples, overhangs
+- TT    (3-wide top)     = tW == 3   -> L2, J2, T2
+- BCUT  (offset bottom)  = bOff > 0  -> L2, T2
+so the emitter needs NO hand membership tables: rails, fans, trees,
+bounds and transitions all derive from the SHAPES tuple; the allocator
+owns every resource map. that closes the phase C design — remaining
+work is implementation.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -109,6 +109,34 @@ reads at c+2 (and repeated reads per column) need parallel-coil rail
 copies where a relay's two contact sets run out — the LEGINV2 pattern,
 allocated per column by CONSUMER COUNT, not hand-laid.
 
+## phase C architecture (survey complete, 14:35Z)
+
+five emitters, in dependency order:
+1. the CONTACT ALLOCATOR (the deepest change): every source signal
+   (state, pos class, mode) has a consumer list; mirrors are minted at
+   ceil(consumers/2) and coil-jack chained; contact sets are assigned
+   by the allocator — replacing every hand-laid POSM3/4/5/6-style set
+   map (those doc comments ARE the hand allocator's ledger today).
+2. the STEP-TREE emitter: shared trunk + state-gated series hops from
+   the (db,dt) offset table + bound refusals at range edges; retNode
+   groups sized by COUNTED refusals (incl. the tree's own — the 3b-4c
+   lesson); rail COPIES (LEGINV2 pattern) minted by consumer count.
+3. the UP-TRANSITION emitter: per state pair s -> s+1 (+ wrap), per
+   pos p with clamped target q: delta sets B2(q)\B1(p), T2(q)\T1(p)
+   as gated rail reads in series behind the one-hot pos fan; join ->
+   clock com; no branch at out-of-range p = the bound refusal.
+4. the B/T FAN emitters: bottom = base {p} + WIDM {p+1} + WID3 {p+2}
+   with BCUT suppression for offset bottoms (L2/T2); top = per-state
+   private pairs (state AND pos -> column net) over the geometry.
+5. budgets: grown() gains a cols dimension per rail from counted
+   consumers; slide machines checked (operator data slides cap at 4 on
+   m1; PIECET top-mask slides fit 6/machine); M10/M11 groups + jack
+   capacities enforced by the existing asserts + claim registry.
+
+size estimate: a full rung arc (comparable to all of 3b). the gate per
+emitter: behavior at 4 (file + check + driver + the dense batch), then
+the width flip to 6 with new-edge tests.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -170,6 +170,18 @@ open questions for the next session:
   LEGB-output-tie pattern) — probably a second primitive join(handleA,
   handleB) that validates capacity.
 
+## the ledger (scratchpad/contact-ledger.mjs -> contact-ledger-8.txt)
+
+extracted the ACTUAL per-set spend from the hand-laid netlist: 113
+mirror-bank relays, zero unwired, and the usage is exactly the two
+kinds the allocator sketch guessed — gates spend GH/KL (arm+NO, 2
+jacks), changeovers GHJ/KLN (all 3) — with a handful of half-spare
+sets (ZM(3).set2, POSM3(3).set2, MMIR set2s...) as the hand's
+headroom. the allocator's count model reproduces reality; its dry-run
+at cols=4 must land within these counts (equal or tighter). the script
+doubles as the C gate's cross-check: run it on the emitted netlist and
+diff the spend per source family.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -336,10 +336,13 @@ coalescing); slave-E overflow (fixed by tail-chaining); ret groups
 ran dry at 3 (grown to 4).
 growth: 8-row 499 -> 627 relays (85 -> 107 machines), 12-row 605 ->
 733 (104 -> 125), dead banks included.
-receipts so far: walk test green, all steering tests green including
-seeded random gameplay; full file + check + driver pending, then the
-dense batch before any deploy. the fence (cols !== 4) STAYS until the
-fan + transition emitters land.
+receipts: FULL SET GREEN at 4 — walk + all steering, the three legacy
+failures fixed via slide-or-ring member pairs on the retired fork
+relays' free sets (af97236), full file 32 green, check 210 green,
+driver end to end (the wall breathes at 8 tile rows / 125 machines).
+the dense batch on the emitter tip is running; its green gates the
+deploy. the fence (cols !== 4) STAYS until the fan + transition
+emitters land — those are the next work units.
 
 ## traps to respect (from the rows job + 3b)
 

--- a/_notes/wider-well.md
+++ b/_notes/wider-well.md
@@ -199,6 +199,22 @@ diff the spend per source family.
   VMODEM(3); left-0 rides VMODEM(2).set2 — request order in tree order
   reproduces the hand map exactly, so the SET gate must hold).
 
+## pilot outcome + strategy (14:55Z)
+
+VMODEM is MirrorBank-managed (commit ab5472a): 8 requests in hand order,
+wire-multiset identical at both geometries, ledger identical, walk test
+green. the splice-tail nuance held (ring-state union enters at the
+chain tail's E jack — the bank mints the same wires, the splice lands
+on the same net).
+
+DECISION: no more hand-order bank conversions — the plumbing is proven,
+and the step-tree emitter will reassign sets anyway (its request order
+is emitter order, gated behaviorally per the C gate). next unit: the
+step-tree emitter — generate the right/wall/left trees from the check
+table's (db,dt) offsets + bounds, requesting sets from MirrorBanks,
+first reproducing behavior at cols=4 (suite + driver + dense batch),
+then unlocking 5/6.
+
 ## traps to respect (from the rows job + 3b)
 
 - a borrowed contact set is free only if arm AND throws are unwired.

--- a/src/circuits/contact-alloc.ts
+++ b/src/circuits/contact-alloc.ts
@@ -1,0 +1,77 @@
+// the contact allocator (wider-well phase C, emitter 0 — see
+// _notes/wider-well.md). A relay has exactly two contact sets; the
+// hand-laid mirror banks (POSM3..6, SM/ZM, MMIR*, ...) spend them via
+// per-block ledger comments that only the author could check. This
+// object makes the ledger mechanical: a MirrorBank owns one layout
+// bank of mirror relays for one source signal, mints contact sets in
+// request order, emits the coil-chain wires itself, and throws the
+// moment a consumer would overflow the bank or share a set (the
+// tie-point law: a contact set serves ONE consumer — jacks are
+// permanent ties, so a second consumer on the same set bridges nets
+// through the shared jack whether the contact is open or not).
+//
+// v1 scope: plain mirrors only (coil parallels the source's coil net).
+// Gated reads (coil = rail AND state, the LTS/LTZ class) stay
+// hand-wired; the bank can still hand them sets via source: null.
+
+export interface ContactSet {
+  relay: number;
+  set: 1 | 2;
+  arm: string; // H (set 1) or L (set 2)
+  no: string; // G or K
+  nc: string; // J or N
+}
+
+export type SetKind = 'gate' | 'changeover';
+
+export interface MirrorBankOpts {
+  name: string; // for errors and the spend ledger
+  // relay whose coil net the mirror chain parallels; null = the caller
+  // wires the first mirror's coil feed itself (gated banks)
+  source: number | null;
+  base: number; // first mirror relay index (the layout's take())
+  capacity: number; // mirror relays the layout granted
+  w: string[]; // the circuit's wire list (coil wires are emitted here)
+  R: (n: number, jack: string) => string;
+  minusOf: (n: number) => string;
+}
+
+export class MirrorBank {
+  private minted = 0; // mirrors whose coil wires exist
+  private setsSpent = 0;
+  private readonly kinds: SetKind[] = [];
+  constructor(private readonly o: MirrorBankOpts) {}
+
+  /** next unspent contact set, minting a new mirror when both sets of
+   *  every minted mirror are gone. records the kind for the ledger. */
+  request(kind: SetKind): ContactSet {
+    const mirror = Math.floor(this.setsSpent / 2);
+    if (mirror >= this.o.capacity)
+      throw new Error(
+        `${this.o.name}: bank exhausted (${this.o.capacity} mirrors / ${this.o.capacity * 2} sets; ` +
+          `request #${this.setsSpent + 1})`
+      );
+    while (this.minted <= mirror) this.mint();
+    const set = ((this.setsSpent % 2) + 1) as 1 | 2;
+    this.setsSpent++;
+    this.kinds.push(kind);
+    const relay = this.o.base + mirror;
+    return set === 1
+      ? { relay, set, arm: 'H', no: 'G', nc: 'J' }
+      : { relay, set, arm: 'L', no: 'K', nc: 'N' };
+  }
+
+  private mint(): void {
+    const { source, base, w, R, minusOf } = this.o;
+    const n = base + this.minted;
+    const prev = this.minted === 0 ? source : base + this.minted - 1;
+    if (prev !== null) w.push(`${R(prev, 'E')}/${R(n, 'E')}`);
+    w.push(`${R(n, 'F')}/${minusOf(n)}`);
+    this.minted++;
+  }
+
+  /** the spend ledger: relays minted, sets spent, kinds in order. */
+  spent(): { relays: number; sets: number; kinds: readonly SetKind[] } {
+    return { relays: this.minted, sets: this.setsSpent, kinds: this.kinds };
+  }
+}

--- a/src/circuits/contact-alloc.ts
+++ b/src/circuits/contact-alloc.ts
@@ -40,7 +40,10 @@ export class MirrorBank {
   private minted = 0; // mirrors whose coil wires exist
   private setsSpent = 0;
   private readonly kinds: SetKind[] = [];
-  constructor(private readonly o: MirrorBankOpts) {}
+  private readonly o: MirrorBankOpts;
+  constructor(o: MirrorBankOpts) {
+    this.o = o;
+  }
 
   /** next unspent contact set, minting a new mirror when both sets of
    *  every minted mirror are gone. records the kind for the ledger. */

--- a/src/circuits/contact-alloc.ts
+++ b/src/circuits/contact-alloc.ts
@@ -78,3 +78,61 @@ export class MirrorBank {
     return { relays: this.minted, sets: this.setsSpent, kinds: this.kinds };
   }
 }
+
+/** a gated rail read: a relay whose coil is fed from a rail tap THROUGH
+ *  a state-gate contact (coil = rail AND state) — dead in every other
+ *  mode, so its NC contacts pass tree samples through untouched (the
+ *  LTS/LTZ pattern). Each read() wires one such relay and returns both
+ *  its contact sets; the caller owns reuse (two trees sharing the same
+ *  state x column read take one set each of one read relay). */
+export interface GatedRead {
+  relay: number;
+  set1: ContactSet;
+  set2: ContactSet;
+}
+
+export class GatedReadPool {
+  private used = 0;
+  private readonly o: MirrorBankOpts; // source is unused (null by contract)
+  constructor(o: MirrorBankOpts) {
+    this.o = o;
+  }
+
+  /** wire a new gated read: railTap -> gate.arm, gate.no -> coil E, F ->
+   *  minus. the gate contact set comes from a state mirror bank. */
+  read(railTap: string, gate: ContactSet): GatedRead {
+    if (this.used >= this.o.capacity)
+      throw new Error(`${this.o.name}: pool exhausted (${this.o.capacity} reads; request #${this.used + 1})`);
+    const n = this.o.base + this.used++;
+    const { w, R, minusOf } = this.o;
+    w.push(`${railTap}/${R(gate.relay, gate.arm)}`);
+    w.push(`${R(gate.relay, gate.no)}/${R(n, 'E')}`);
+    w.push(`${R(n, 'F')}/${minusOf(n)}`);
+    return {
+      relay: n,
+      set1: { relay: n, set: 1, arm: 'H', no: 'G', nc: 'J' },
+      set2: { relay: n, set: 2, arm: 'L', no: 'K', nc: 'N' },
+    };
+  }
+
+  /** one more relay on an EXISTING read's gated feed (parallel coil,
+   *  chained at the coil jacks — the LTZ(2)/LTZ(3) pattern) for reads
+   *  that need more than two contact sets. */
+  extend(of: GatedRead): GatedRead {
+    if (this.used >= this.o.capacity)
+      throw new Error(`${this.o.name}: pool exhausted (${this.o.capacity} reads; request #${this.used + 1})`);
+    const n = this.o.base + this.used++;
+    const { w, R, minusOf } = this.o;
+    w.push(`${R(of.relay, 'E')}/${R(n, 'E')}`);
+    w.push(`${R(n, 'F')}/${minusOf(n)}`);
+    return {
+      relay: n,
+      set1: { relay: n, set: 1, arm: 'H', no: 'G', nc: 'J' },
+      set2: { relay: n, set: 2, arm: 'L', no: 'K', nc: 'N' },
+    };
+  }
+
+  spent(): number {
+    return this.used;
+  }
+}

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -427,6 +427,9 @@ export interface TetrisLayout {
   STPUNION: number; STPUNION_CAP: number;
   STPUGATE: number; STPUGATE_CAP: number;
   STPREAD: number; STPREAD_CAP: number;
+  FANPOS: number; FANPOS_CAP: number;
+  FANRAIL: number; FANRAIL_CAP: number;
+  FANMIR: number; FANMIR_CAP: number;
   btnMachine: number; // the dedicated (relay-free) button/slide machine
   machines: number;
   relays: number; // wired coils (the junction gap is com-only)
@@ -511,6 +514,10 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   const stpUnionBase = take(10); // the union rails (B0..WALLB)
   const stpUGateBase = take(12 * (cols - 1)); // union mirrors: per-tree gate contacts
   const stpReadBase = take(8 * (cols - 1)); // the gated read pool
+  // the fan emitter's banks (B/T fans as offset rails x pos taps)
+  const fanPosBase = take(4 * cols); // per-position mirror banks
+  const fanRailBase = take(4); // T-fan offset rails (T-1, T0, T1, T2)
+  const fanMirBase = take(6 * Math.ceil(cols / 2) + 8); // rail mirrors (private tap sets)
   return {
     rows,
     cols,
@@ -591,6 +598,9 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
     STPUNION: stpUnionBase, STPUNION_CAP: 10,
     STPUGATE: stpUGateBase, STPUGATE_CAP: 12 * (cols - 1),
     STPREAD: stpReadBase, STPREAD_CAP: 8 * (cols - 1),
+    FANPOS: fanPosBase, FANPOS_CAP: 4 * cols,
+    FANRAIL: fanRailBase, FANRAIL_CAP: 4,
+    FANMIR: fanMirBase, FANMIR_CAP: 6 * Math.ceil(cols / 2) + 8,
     btnMachine: Math.ceil(n / 6),
     machines: Math.ceil(n / 6) + 1,
     relays: n - (rows - 3),
@@ -693,6 +703,9 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   for (let k = 0; k < L8.STPUNION_CAP; k++) claim('STPUNION', L8.STPUNION + k);
   for (let k = 0; k < L8.STPUGATE_CAP; k++) claim('STPUGATE', L8.STPUGATE + k);
   for (let k = 0; k < L8.STPREAD_CAP; k++) claim('STPREAD', L8.STPREAD + k);
+  for (let k = 0; k < L8.FANPOS_CAP; k++) claim('FANPOS', L8.FANPOS + k);
+  for (let k = 0; k < L8.FANRAIL_CAP; k++) claim('FANRAIL', L8.FANRAIL + k);
+  for (let k = 0; k < L8.FANMIR_CAP; k++) claim('FANMIR', L8.FANMIR + k);
 
 }
 
@@ -1440,7 +1453,6 @@ export function tetrisCircuit(rows = 8, cols = 4): {
     w.push(`${R(rr, nc)}/${R(POSS(j), 'H')}`, `${R(POSS(j), 'G')}/${comOf(POSS(j))}`);
     w.push(`${comOf(POSS(j))}/${R(POSS(j), 'E')}`, `${R(POSS(j), 'F')}/${minusOf(POSS(j))}`);
     w.push(`${comOf(POSS(j))}/${R(POSM(j), 'E')}`, `${R(POSM(j), 'F')}/${minusOf(POSM(j))}`);
-    w.push(`${R(POSS(j), 'K')}/${R(PIECE(j), 'E')}`);
   }
   // re-home on the RESET tick (piece death), NOT the spawn tick: a
   // spawn-tick reset would flip the register mid-tick under a merged
@@ -1485,9 +1497,6 @@ export function tetrisCircuit(rows = 8, cols = 4): {
     w.push(`${R(POSM(j), 'E')}/${R(POSM2(j), 'E')}`, `${R(POSM2(j), 'F')}/${minusOf(POSM2(j))}`);
     w.push(`${plusOf(POSM2(j))}/${R(POSM2(j), 'H')}`);
   }
-  w.push(`${R(POSM2(0), 'G')}/${R(WIDM, 'H')}`, `${R(WIDM, 'G')}/${R(PIECE(1), 'E')}`);
-  w.push(`${R(POSM2(1), 'G')}/${R(WIDM, 'L')}`, `${R(WIDM, 'K')}/${R(PIECE(2), 'E')}`);
-  w.push(`${R(POSM2(2), 'G')}/${R(WIDM2, 'H')}`, `${R(WIDM2, 'G')}/${R(PIECE(3), 'E')}`);
 
   // ---------- the piece register, increment 2: lateral legality ----------
   // "Buttons request, contacts decide" — the same doctrine as the fall.
@@ -1606,7 +1615,11 @@ export function tetrisCircuit(rows = 8, cols = 4): {
     // with cols: L2 = 4 members + (cols-1) bypasses + (cols-3) reads,
     // T2 = 4 + (cols-1) + (cols-1), S = 4 + (cols-2), J1 = 3 + (cols-2)
     // state 0 (1x1) also anchors the LEGACY pairs: five more sets
-    const caps = [3, 1, 2, 2, Math.ceil((cols + 2) / 2), 2, 2, Math.ceil((cols + 1) / 2), 2, cols + 1, 2, cols + 2];
+    // tree memberships + per-tree singles + the FAN rails' memberships
+    // + the legacy gates; growing states get a (cols-4) term; the bank
+    // asserts catch any drift
+    const capg = Math.max(0, cols - 4);
+    const caps = [4, 1, 2, 3, 4 + capg, 3, 3, 3 + capg, 3, 6 + capg, 4, 7 + capg];
     let off = 0;
     for (let i = 0; i < NSTATES; i++) {
       stBanks.push(
@@ -1765,6 +1778,108 @@ export function tetrisCircuit(rows = 8, cols = 4): {
       }
       w.push(`${pending[0]}/${comOf(POSA(c))}`);
     }
+  }
+  // ---------- the fan emitters: B and T fans as offset rails ----------
+  // the hand's B fan was ALREADY this factorization (base + WIDM + WID3
+  // rails with BCUT as the offset-bottom suppression); the T fan becomes
+  // its mirror: per offset d, a rail = union of states whose top span
+  // covers d, and per column j a PRIVATE series pair (pos p=j-d AND a
+  // rail-mirror set) into PIECET(j).E — same backfeed safety as the
+  // hand's per-state pairs (every tap is two private contact sets; the
+  // one-hot register means a dead rail ties at most one coil net).
+  // the legacy slide modes ride as pairs on VMODEM(2)/WIDM4 free sets.
+  const fanPos: MirrorBank[] = [];
+  for (let p = 0; p < cols; p++) {
+    if (p === 0) {
+      // pos 0's slave E carries the home-set wire (full): feed the bank
+      // through POSM2(0)'s freed set2 instead (the old T fan spent it)
+      fanPos.push(new MirrorBank({ name: 'FANPOS0', source: null, base: L.FANPOS, capacity: 4, w, R, minusOf }));
+      w.push(`${plusOf(POSM2(0))}/${R(POSM2(0), 'L')}`, `${R(POSM2(0), 'K')}/${R(L.FANPOS, 'E')}`);
+    } else {
+      fanPos.push(new MirrorBank({ name: `FANPOS${p}`, source: POSS(p), base: L.FANPOS + 4 * p, capacity: 4, w, R, minusOf }));
+    }
+  }
+  // the B fan: base = the chained POSS arms behind BCUT's NC (offset
+  // bottoms suppress it); wide/third-column taps mint from mirror banks
+  // on the WIDM / WID3M compatibility nets (slide OR ring by the splices)
+  w.push(`${plusOf(BCUT)}/${R(BCUT, 'H')}`, `${R(BCUT, 'J')}/${R(POSS(0), 'L')}`);
+  for (let j = 1; j < cols; j++) w.push(`${R(POSS(j - 1), 'L')}/${R(POSS(j), 'L')}`);
+  for (let j = 0; j < cols; j++) w.push(`${R(POSS(j), 'K')}/${R(PIECE(j), 'E')}`); // the base outputs
+  // the WIDM / WID3M coil nets are hole-saturated (slide feeds + splices)
+  // so the tap banks mirror THROUGH a retired fork contact instead of
+  // parallel-coiling: + -> WIDM4.set1 (freed by the tree emitter) -> the
+  // bank's coil chain; same signal, one freed contact set each
+  const widmBank = new MirrorBank({ name: 'FANWIDM', source: null, base: L.FANMIR, capacity: Math.ceil(cols / 2), w, R, minusOf });
+  w.push(`${plusOf(WIDM4)}/${R(WIDM4, 'H')}`, `${R(WIDM4, 'G')}/${R(L.FANMIR, 'E')}`);
+  const wid3Bank = new MirrorBank({ name: 'FANWID3', source: null, base: L.FANMIR + Math.ceil(cols / 2), capacity: Math.ceil(cols / 2), w, R, minusOf });
+  w.push(`${plusOf(WID3M)}/${R(WID3M, 'H')}`, `${R(WID3M, 'G')}/${R(L.FANMIR + Math.ceil(cols / 2), 'E')}`);
+  for (let j = 1; j < cols; j++) {
+    const bOuts: string[] = [];
+    {
+      const wm = widmBank.request('gate');
+      const pm = fanPos[j - 1].request('gate');
+      w.push(`${plusOf(wm.relay)}/${R(wm.relay, wm.arm)}`);
+      w.push(`${R(wm.relay, wm.no)}/${R(pm.relay, pm.arm)}`);
+      bOuts.push(R(pm.relay, pm.no));
+    }
+    if (j >= 2) {
+      const tm = wid3Bank.request('gate');
+      const pm = fanPos[j - 2].request('gate');
+      w.push(`${plusOf(tm.relay)}/${R(tm.relay, tm.arm)}`);
+      w.push(`${R(tm.relay, tm.no)}/${R(pm.relay, pm.arm)}`);
+      bOuts.push(R(pm.relay, pm.no));
+    }
+    for (let k = 1; k < bOuts.length; k++) w.push(`${bOuts[k - 1]}/${bOuts[k]}`);
+    w.push(`${bOuts[bOuts.length - 1]}/${R(PIECE(j), 'E')}`);
+  }
+  // the T fan: offset rails from the geometry (members = states whose
+  // top span covers the offset), one rail relay + a mirror bank each
+  const tRailBanks: Array<{ bank: MirrorBank; d: number }> = [];
+  {
+    let railN = 0;
+    let mirOff = 2 * Math.ceil(cols / 2);
+    for (const d of [-1, 0, 1, 2]) {
+      const members: number[] = [];
+      for (let i = 0; i < NSTATES; i++) {
+        const sh = SHAPES[i];
+        // STAGGERED states only: a symmetric top (2tall, O, the legacy
+        // slide-talls) writes phase 2 through the B fan — the T fan
+        // exists exactly for tops that DIFFER from the bottom footprint
+        const staggered = sh.tW > 0 && (sh.tOff !== sh.bOff || sh.tW !== sh.bW);
+        if (staggered && d >= sh.tOff && d < sh.tOff + sh.tW) members.push(i);
+      }
+      const u = L.FANRAIL + railN++;
+      let prev: string | null = null;
+      for (const si of members) {
+        const cs = stBanks[si].request('gate');
+        w.push(`${plusOf(cs.relay)}/${R(cs.relay, cs.arm)}`);
+        if (prev !== null) w.push(`${prev}/${R(cs.relay, cs.no)}`);
+        prev = R(cs.relay, cs.no);
+      }
+      // (no legacy pairs here: the legacy slide-talls are SYMMETRIC, so
+      // their phase-2 top rides the B fan; legacy STAG tops come from
+      // the TOPMASK slides directly)
+      w.push(`${prev as string}/${R(u, 'E')}`, `${R(u, 'F')}/${minusOf(u)}`);
+      const bank = new MirrorBank({ name: `FANT${d}`, source: u, base: L.FANMIR + mirOff, capacity: Math.ceil(cols / 2) + 1, w, R, minusOf });
+      mirOff += Math.ceil(cols / 2) + 1;
+      if (mirOff > L.FANMIR_CAP) throw new Error('fan mirrors overflow');
+      tRailBanks.push({ bank, d });
+    }
+  }
+  // per column: chain the tap outputs and enter the coil net once
+  for (let j = 0; j < cols; j++) {
+    const outs: string[] = [];
+    for (const { bank, d } of tRailBanks) {
+      const p = j - d;
+      if (p < 0 || p >= cols) continue;
+      const rm = bank.request('gate');
+      const pm = fanPos[p].request('gate');
+      w.push(`${plusOf(rm.relay)}/${R(rm.relay, rm.arm)}`);
+      w.push(`${R(rm.relay, rm.no)}/${R(pm.relay, pm.arm)}`);
+      outs.push(R(pm.relay, pm.no));
+    }
+    for (let k = 1; k < outs.length; k++) w.push(`${outs[k - 1]}/${outs[k]}`);
+    if (outs.length > 0) w.push(`${outs[outs.length - 1]}/${R(PIECET(j), 'E')}`);
   }
 
   // ---------- game over: the stack topped out ----------
@@ -2002,19 +2117,9 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // first multivac counter's trap). Multi-branch columns chain their
   // outputs; each PIECET(j).E takes one wire at its free hole.
   // T(0) = S & pos1
-  w.push(`${plusOf(SM(0))}/${R(SM(0), 'H')}`, `${R(SM(0), 'G')}/${R(POSM2(1), 'L')}`, `${R(POSM2(1), 'K')}/${R(PIECET(0), 'E')}`);
   // T(1) = S & pos1  |  S & pos2  |  Z & pos0
-  w.push(`${plusOf(SM(0))}/${R(SM(0), 'L')}`, `${R(SM(0), 'K')}/${R(POSM3(1), 'H')}`);
-  w.push(`${plusOf(SM(1))}/${R(SM(1), 'H')}`, `${R(SM(1), 'G')}/${R(POSM2(2), 'L')}`);
-  w.push(`${plusOf(ZM(0))}/${R(ZM(0), 'H')}`, `${R(ZM(0), 'G')}/${R(POSM2(0), 'L')}`);
-  w.push(`${R(POSM3(1), 'G')}/${R(POSM2(2), 'K')}`, `${R(POSM2(2), 'K')}/${R(POSM2(0), 'K')}`, `${R(POSM2(0), 'K')}/${R(PIECET(1), 'E')}`);
   // T(2) = S & pos2  |  Z & pos0  |  Z & pos1
-  w.push(`${plusOf(SM(1))}/${R(SM(1), 'L')}`, `${R(SM(1), 'K')}/${R(POSM3(3), 'H')}`);
-  w.push(`${plusOf(ZM(0))}/${R(ZM(0), 'L')}`, `${R(ZM(0), 'K')}/${R(POSM3(0), 'H')}`);
-  w.push(`${plusOf(ZM(1))}/${R(ZM(1), 'H')}`, `${R(ZM(1), 'G')}/${R(POSM3(1), 'L')}`);
-  w.push(`${R(POSM3(3), 'G')}/${R(POSM3(0), 'G')}`, `${R(POSM3(0), 'G')}/${R(POSM3(1), 'K')}`, `${R(POSM3(1), 'K')}/${R(PIECET(2), 'E')}`);
   // T(3) = Z & pos1
-  w.push(`${plusOf(ZM(1))}/${R(ZM(1), 'L')}`, `${R(ZM(1), 'K')}/${R(POSM3(2), 'H')}`, `${R(POSM3(2), 'G')}/${R(PIECET(3), 'E')}`);
 
   // ---------- 3b-3b coils: the mode gates and mode-only top reads ------
   // SG mirrors chain off the S state net, ZG off the Z net (their NC/NO
@@ -2140,19 +2245,11 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // (TRPM(1)'s second set is the 3b-4b triple bound in the right-into-2 tree)
   // the B fan's third column: pos(j-2) AND WID3 -> the PIECE(j) coil
   // nets, entering at the WIDM-branch output jacks' free holes
-  w.push(`${plusOf(WID3M)}/${R(WID3M, 'H')}`, `${R(WID3M, 'G')}/${R(POSM5(0), 'H')}`, `${R(POSM5(0), 'G')}/${R(WIDM, 'K')}`);
-  w.push(`${plusOf(WID3M)}/${R(WID3M, 'L')}`, `${R(WID3M, 'K')}/${R(POSM5(4), 'H')}`, `${R(POSM5(4), 'G')}/${R(WIDM2, 'G')}`);
   // the T fan: per-state private pairs onto the column nets' free holes
   // T(0) += L1 & pos0
-  w.push(`${plusOf(L1M(0))}/${R(L1M(0), 'L')}`, `${R(L1M(0), 'K')}/${R(POSM5(0), 'L')}`, `${R(POSM5(0), 'K')}/${R(POSM2(1), 'K')}`);
   // T(1) += T1 & pos0  |  L1 & pos1
-  w.push(`${plusOf(T1M(0))}/${R(T1M(0), 'L')}`, `${R(T1M(0), 'K')}/${R(POSM5(1), 'L')}`, `${R(POSM5(1), 'K')}/${R(POSM3(1), 'G')}`);
-  w.push(`${plusOf(L1M(1))}/${R(L1M(1), 'H')}`, `${R(L1M(1), 'G')}/${R(POSM5(4), 'L')}`, `${R(POSM5(4), 'K')}/${R(POSM5(1), 'K')}`);
   // T(2) += J1 & pos0  |  T1 & pos1
-  w.push(`${plusOf(J1M(0))}/${R(J1M(0), 'L')}`, `${R(J1M(0), 'K')}/${R(POSM5(1), 'H')}`, `${R(POSM5(1), 'G')}/${R(POSM3(3), 'G')}`);
-  w.push(`${plusOf(T1M(1))}/${R(T1M(1), 'H')}`, `${R(T1M(1), 'G')}/${R(POSM5(5), 'L')}`, `${R(POSM5(5), 'K')}/${R(POSM5(1), 'G')}`);
   // T(3) += J1 & pos1
-  w.push(`${plusOf(J1M(1))}/${R(J1M(1), 'H')}`, `${R(J1M(1), 'G')}/${R(POSM5(5), 'H')}`, `${R(POSM5(5), 'G')}/${R(POSM3(2), 'G')}`);
   // transitions into 6/7/8: the root chain extends, each branch reads
   // the target's delta cells (Z->L1 grows bottom p+2 AND top p; L1->J1
   // moves the top stem p -> p+2; J1->T1 moves it p+2 -> p+1)
@@ -2205,8 +2302,6 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${R(BCUT, 'E')}/${R(BCUTM, 'E')}`);
   // the base-column cut: ONE contact ahead of the chained POSS arms
   // (one-hot slaves make the shared arm net legal)
-  w.push(`${plusOf(BCUT)}/${R(BCUT, 'H')}`, `${R(BCUT, 'J')}/${R(POSS(0), 'L')}`);
-  w.push(`${R(POSS(0), 'L')}/${R(POSS(1), 'L')}`, `${R(POSS(1), 'L')}/${R(POSS(2), 'L')}`, `${R(POSS(2), 'L')}/${R(POSS(3), 'L')}`);
   // rails: T2 joins WIDM (at TRP.G's free hole), L2 joins WID3; VMODE and
   // STAG gain one TT contact each (spliced into the 4a links)
   w.push(`${plusOf(T2M(1))}/${R(T2M(1), 'H')}`, `${R(T2M(1), 'G')}/${R(TRP, 'G')}`);
@@ -2215,14 +2310,6 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${R(TRPM(0), 'G')}/${R(TTM(0), 'G')}`, `${R(TTM(0), 'G')}/${R(VMODEM(3), 'E')}`);
   w.push(`${R(TRPM(0), 'K')}/${R(TTM(0), 'K')}`, `${R(TTM(0), 'K')}/${R(STAGM2, 'E')}`);
   // the T fan: six TT x pos branches onto the column nets' free holes
-  w.push(`${plusOf(TTM(1))}/${R(TTM(1), 'H')}`, `${R(TTM(1), 'G')}/${R(POSM5(3), 'L')}`, `${R(POSM5(3), 'K')}/${R(POSM5(0), 'K')}`);
-  w.push(`${plusOf(TTM(1))}/${R(TTM(1), 'L')}`, `${R(TTM(1), 'K')}/${R(POSM6(0), 'H')}`);
-  w.push(`${plusOf(TTM(2))}/${R(TTM(2), 'H')}`, `${R(TTM(2), 'G')}/${R(POSM5(7), 'L')}`);
-  w.push(`${R(POSM6(0), 'G')}/${R(POSM5(7), 'K')}`, `${R(POSM5(7), 'K')}/${R(POSM5(4), 'K')}`);
-  w.push(`${plusOf(TTM(2))}/${R(TTM(2), 'L')}`, `${R(TTM(2), 'K')}/${R(POSM6(0), 'L')}`);
-  w.push(`${plusOf(TTM(3))}/${R(TTM(3), 'H')}`, `${R(TTM(3), 'G')}/${R(POSM6(3), 'H')}`);
-  w.push(`${R(POSM6(0), 'K')}/${R(POSM6(3), 'G')}`, `${R(POSM6(3), 'G')}/${R(POSM5(5), 'K')}`);
-  w.push(`${plusOf(TTM(3))}/${R(TTM(3), 'L')}`, `${R(TTM(3), 'K')}/${R(POSM6(3), 'L')}`, `${R(POSM6(3), 'K')}/${R(POSM5(5), 'G')}`);
   // pos mirror chains for the new contacts
   w.push(`${R(POSM5(3), 'E')}/${R(POSM6(0), 'E')}`, `${R(POSM6(0), 'E')}/${R(POSM6(1), 'E')}`, `${R(POSM6(1), 'E')}/${R(POSM6(2), 'E')}`);
   w.push(`${R(POSM5(7), 'E')}/${R(POSM6(3), 'E')}`, `${R(POSM6(3), 'E')}/${R(POSM6(4), 'E')}`, `${R(POSM6(4), 'E')}/${R(POSM6(5), 'E')}`);

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -305,6 +305,7 @@ export const MACHINES = 85; // relays through m83.3 + the dedicated button machi
 // and write machinery are per-column and scale on their own rung.
 export interface TetrisLayout {
   rows: number;
+  cols: number;
   A0: number; A0m: number; A1: number; A2: number;
   W: (r: number, k: number) => number;
   CELL: (r: number, j: number) => number;
@@ -381,9 +382,14 @@ export interface TetrisLayout {
   relays: number; // wired coils (the junction gap is com-only)
 }
 
-export function tetrisLayout(rows: number): TetrisLayout {
+export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   if (rows < 4 || rows % 2 !== 0) throw new Error('rows must be even and >= 4');
-  const cols = 4;
+  // the second parameterization axis (see _notes/wider-well.md). the
+  // mechanical loops below already flow from this value; the column-CLASS
+  // sites (POSM4/5/6 maps, per-state bound contacts, the D-tap tree
+  // shapes, mirror/cut/rail COUNTS) are still hand-laid for 4 — the fence
+  // comes down subsystem by subsystem as each class map is derived.
+  if (cols !== 4) throw new Error('cols !== 4 needs the class derivations (wider-well phase C)');
   let n = 0;
   const take = (k: number) => {
     const a = n;
@@ -391,7 +397,9 @@ export function tetrisLayout(rows: number): TetrisLayout {
     return a;
   };
   const aBase = take(4);
-  const wBase = take(rows * 4);
+  // W per row: gates + breakers, one contact SET per column, two sets per
+  // relay -> 2*ceil(cols/2) relays (== cols when even; the fence holds 4)
+  const wBase = take(rows * cols);
   const cellBase = take(rows * cols);
   const ringBase = take(rows * 3);
   const mirBase = take(rows * 2);
@@ -448,8 +456,9 @@ export function tetrisLayout(rows: number): TetrisLayout {
   const oscBase = take(2); // 3b-5: TOSC, TDRV (the self-tick oscillator)
   return {
     rows,
+    cols,
     A0: aBase, A0m: aBase + 1, A1: aBase + 2, A2: aBase + 3,
-    W: (r, k) => wBase + 4 * r + k,
+    W: (r, k) => wBase + cols * r + k,
     CELL: (r, j) => cellBase + cols * r + j,
     RING: (i, part) => ringBase + 3 * i + part,
     MIRA: r => mirBase + 2 * r,
@@ -709,13 +718,13 @@ export function tetrisLayout(rows: number): TetrisLayout {
   eq('btnMachine3', L.btnMachine, WIDSLIDE.machine);
 }
 
-export function tetrisCircuit(rows = 8): {
+export function tetrisCircuit(rows = 8, cols = 4): {
   wires: string[];
   rails: string[][]; // data rail j -> its chained groups
   layout: TetrisLayout; // this build's index map (== the exports at rows=8)
   btnMachine: number; // LEFT/RIGHT buttons + WID slide live here (m40 classic)
 } {
-  const L = tetrisLayout(rows);
+  const L = tetrisLayout(rows, cols);
   // shadow the default-geometry exports with this build's layout: the
   // whole wiring body below reads THESE, so a taller well is a parameter
   const {
@@ -779,12 +788,12 @@ export function tetrisCircuit(rows = 8): {
     R(A0m, 'J'), R(A0m, 'G'), R(A0m, 'N'), R(A0m, 'K'),
   ];
 
-  const dataRails = [takeGroups(grown(6, 2)), takeGroups(grown(6, 2)), takeGroups(grown(6, 2)), takeGroups(grown(6, 2))]; // 6: 21 taps/rail at 8 rows since the T bank joined
+  const dataRails = Array.from({ length: cols }, () => takeGroups(grown(6, 2))); // 6: 21 taps/rail at 8 rows since the T bank joined
   const railJack = (j: number, hole: number) => dataRails[j][Math.floor(hole / 4)];
   // chain each rail's groups (each link burns one hole on both sides, so a
   // group offers 4 fresh holes; railJack spreads consumers accordingly)
   for (const g of dataRails) for (let i = 1; i < g.length; i++) w.push(`${g[i - 1]}/${g[i]}`);
-  const railUse: number[] = [0, 0, 0, 0];
+  const railUse: number[] = Array(cols).fill(0);
   const tapRail = (j: number) => railJack(j, railUse[j]++);
 
   // gates (W, W' on comA) and breakers (W'', W''' on comB) are triggered
@@ -797,36 +806,39 @@ export function tetrisCircuit(rows = 8): {
   // breaking holds. The game's lock path does the full OR-write, CLEARP
   // does the clearing, and the register-file file keeps the classic
   // destructive-write machinery.
+  const nGates = Math.ceil(cols / 2); // W(r, 0..nGates-1) gates, then breakers
   for (let r = 0; r < rows; r++) {
     const comA = comOf(W(r, 0));
-    const comB = comOf(W(r, 2));
+    const comB = comOf(W(r, nGates));
     // the 3-bit operator-write decoder addresses 8 rows; on a taller well
     // the deep rows are game-writable only (locks fire W via the MIRA
     // triggers, not the decoder)
     if (r < 8) w.push(`${sel[r]}/${comA}`);
-    for (let k = 0; k < 4; k++) {
-      const src = k < 2 ? comA : comB;
+    for (let k = 0; k < 2 * nGates; k++) {
+      const src = k < nGates ? comA : comB;
       w.push(`${src}/${R(W(r, k), 'E')}`, `${R(W(r, k), 'F')}/${minusOf(W(r, k))}`);
     }
-    for (let j = 0; j < 4; j++) {
+    for (let j = 0; j < cols; j++) {
       const c = CELL(r, j);
       const [arm, no, nc] = j % 2 === 0 ? ['H', 'G', 'J'] : ['L', 'K', 'N'];
-      const g = W(r, j < 2 ? 0 : 1);
+      const g = W(r, Math.floor(j / 2));
       w.push(`${tapRail(j)}/${R(g, arm)}`, `${R(g, no)}/${comOf(c)}`); // data gate
       // the breaker contact serves BOTH cell-private paths with one arm:
       // NC = the hold (idle), NO = the lock readback (press) — the cell's
       // own + through its own contact onto its own rail. Any SHARED readback
       // rail bridges the write rails through a stacked row's ON cells (two
       // drafts of this file died to exactly that, one row down and one up).
-      const b = W(r, j < 2 ? 2 : 3);
+      const b = W(r, nGates + Math.floor(j / 2));
       w.push(`${plusOf(c)}/${R(b, arm)}`, `${R(b, nc)}/${R(c, 'H')}`); // hold break
       w.push(`${R(b, no)}/${R(c, 'L')}`); // press-scoped readback feed
       w.push(`${R(c, 'G')}/${comOf(c)}`);
       w.push(`${comOf(c)}/${R(c, 'E')}`, `${R(c, 'F')}/${minusOf(c)}`);
     }
   }
-  // operator data slides on m1 sections 1-4
-  for (let j = 0; j < 4; j++) {
+  // operator data slides on m1 sections 1-4 (m1.5 is the tick slide and
+  // m1.6 START, so columns past 4 have no operator slide — the game's own
+  // writes cover them; phase C revisits if operator masks must widen)
+  for (let j = 0; j < Math.min(cols, 4); j++) {
     w.push(`m1.${j + 1}+/m1.${j + 1}S`, `m1.${j + 1}T/${tapRail(j)}`);
   }
 
@@ -885,7 +897,7 @@ export function tetrisCircuit(rows = 8): {
   // mirror for the sense — are wired at those relays; there is NO shared
   // readback rail anywhere: every shared variant bridged the write rails)
   for (let r = 0; r < rows; r++) {
-    for (let j = 0; j < 4; j++) {
+    for (let j = 0; j < cols; j++) {
       w.push(`${R(CELL(r, j), 'K')}/${tapRail(j)}`);
     }
   }
@@ -994,14 +1006,14 @@ export function tetrisCircuit(rows = 8): {
   // bridged them one node further up: only fully private feeds are safe).
   for (let r = 0; r < rows; r++) {
     w.push(`${tap(railB0p, bpUse)}/${R(MIRA(r), 'H')}`, `${R(MIRA(r), 'G')}/${comOf(W(r, 0))}`);
-    w.push(`${tap(railB0, b0Use)}/${R(MIRA(r), 'L')}`, `${R(MIRA(r), 'K')}/${comOf(W(r, 2))}`);
+    w.push(`${tap(railB0, b0Use)}/${R(MIRA(r), 'L')}`, `${R(MIRA(r), 'K')}/${comOf(W(r, nGates))}`);
     if (r < rows - 1) {
-      const taps: Array<[number, string, string]> = [
-        [MIRB(r), 'H', 'G'], [MIRB(r), 'L', 'K'],
-        [MIRB2(r), 'H', 'G'], [MIRB2(r), 'L', 'K'],
-      ];
-      for (let j = 0; j < 4; j++) {
-        const [mr, arm, no] = taps[j];
+      // one contact set per column: MIRB carries columns 0-1, MIRB2 2-3
+      // (a wider well needs more mirrors per row — phase C grows the bank)
+      const mirs = [MIRB(r), MIRB2(r)];
+      for (let j = 0; j < cols; j++) {
+        const mr = mirs[Math.floor(j / 2)];
+        const [arm, no] = j % 2 === 0 ? ['H', 'G'] : ['L', 'K'];
         w.push(`${plusOf(mr)}/${R(mr, arm)}`, `${R(mr, no)}/${R(CELL(r + 1, j), 'L')}`);
       }
     } else {
@@ -1018,12 +1030,12 @@ export function tetrisCircuit(rows = 8): {
   // colFan needs no feed to bridge, a jack is a tie — and a collapse move's
   // row content would leak across the masked columns (the mask can change
   // between the lock and the collapse, so this is reachable in play).
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < cols; j++) {
     const p = PIECE(j);
-    const cutc = j < 2 ? CUTC1 : CUTC2;
-    const cutb = j < 2 ? CUTB1 : CUTB2;
+    const cutc = [CUTC1, CUTC2][Math.floor(j / 2)]; // one cut set per column
+    const cutb = [CUTB1, CUTB2][Math.floor(j / 2)]; // (phase C grows the banks)
     const [cArm, cNc] = j % 2 === 0 ? ['H', 'J'] : ['L', 'N'];
-    const cutk = j < 2 ? CUTC3 : CUTC4;
+    const cutk = [CUTC3, CUTC4][Math.floor(j / 2)];
     // coils fed from the POS register (see the piece-register section) —
     // the per-column slides are gone; position is machine state now
     w.push(`${R(p, 'F')}/${minusOf(p)}`);
@@ -1032,7 +1044,7 @@ export function tetrisCircuit(rows = 8): {
     // of the bottom-press leak) -> CUTC (NC, opens during collapses) ->
     w.push(`${colFan}/${R(cutb, cArm)}`, `${R(cutb, cNc)}/${R(cutc, cArm)}`, `${R(cutc, cNc)}/${R(p, 'H')}`);
     w.push(`${R(p, 'G')}/${tapRail(j)}`);
-    const cutb2 = j < 2 ? CUTB3 : CUTB4;
+    const cutb2 = [CUTB3, CUTB4][Math.floor(j / 2)];
     w.push(`${tapRail(j)}/${R(p, 'L')}`, `${R(p, 'K')}/${R(cutb2, cArm)}`);
     w.push(`${R(cutb2, cNc)}/${R(cutk, cArm)}`, `${R(cutk, cNc)}/${collideNode}`);
   }
@@ -1056,19 +1068,19 @@ export function tetrisCircuit(rows = 8): {
   // (a full row could never persist), found by their tests. By the wave the
   // delayed feed arrives, the rails carry only the mask and the token
   // row's own readback — the true line state.
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < cols; j++) {
     w.push(`${tapRail(j)}/${R(LINE(j), 'E')}`, `${R(LINE(j), 'F')}/${minusOf(LINE(j))}`);
   }
   w.push(`${plusOf(RAILGATE2)}/${R(RAILGATE2, 'H')}`, `${R(RAILGATE2, 'G')}/${R(LINEDLY, 'E')}`);
   w.push(`${R(LINEDLY, 'F')}/${minusOf(LINEDLY)}`);
   w.push(`${plusOf(LINEDLY)}/${R(LINEDLY, 'H')}`, `${R(LINEDLY, 'G')}/${R(LINE(0), 'H')}`);
-  w.push(`${R(LINE(0), 'G')}/${R(LINE(1), 'H')}`, `${R(LINE(1), 'G')}/${R(LINE(2), 'H')}`);
+  for (let j = 1; j < cols - 1; j++) w.push(`${R(LINE(j - 1), 'G')}/${R(LINE(j), 'H')}`);
   // the chain fires CPSET, and CPSET's contact — sourcing from + — sets
   // CLEARP. Wiring the chain straight into CLEARP's com lets CLEARP's
   // +-armed latch backfeed rail A through the still-closed LINE contacts
   // after the release: the whole press state froze as one parasitic latch
   // (this file's line-clear debug trace caught the entire circuit at it=1).
-  w.push(`${R(LINE(2), 'G')}/${R(LINE(3), 'H')}`, `${R(LINE(3), 'G')}/${comOf(CPSET)}`);
+  w.push(`${R(LINE(cols - 2), 'G')}/${R(LINE(cols - 1), 'H')}`, `${R(LINE(cols - 1), 'G')}/${comOf(CPSET)}`);
   w.push(`${comOf(CPSET)}/${R(CPSET, 'E')}`, `${R(CPSET, 'F')}/${minusOf(CPSET)}`);
   w.push(`${plusOf(CPSET)}/${R(CPSET, 'H')}`, `${R(CPSET, 'G')}/${comOf(CLEARP)}`);
   w.push(`${comOf(CLEARP)}/${R(CLEARP, 'E')}`, `${R(CLEARP, 'F')}/${minusOf(CLEARP)}`);
@@ -1400,7 +1412,7 @@ export function tetrisCircuit(rows = 8): {
   // direction chains: one gate contact, POSM arms daisy-chained behind it
   w.push(`${plusOf(LEFTM)}/${R(LEFTM, 'H')}`, `${R(LEFTM, 'G')}/${R(POSM(0), 'H')}`);
   w.push(`${plusOf(RIGHTM)}/${R(RIGHTM, 'H')}`, `${R(RIGHTM, 'G')}/${R(POSM(0), 'L')}`);
-  for (let j = 1; j < 4; j++) {
+  for (let j = 1; j < cols; j++) {
     w.push(`${R(POSM(j - 1), 'H')}/${R(POSM(j), 'H')}`);
     w.push(`${R(POSM(j - 1), 'L')}/${R(POSM(j), 'L')}`);
   }
@@ -1414,7 +1426,7 @@ export function tetrisCircuit(rows = 8): {
   // one refused press would wipe the ring. The edge self-loops stay
   // ungated: stepping into your own column is always legal.
   w.push(`${R(POSM(0), 'G')}/${comOf(POSA(0))}`); // left self-loop at 0
-  w.push(`${R(POSM(3), 'K')}/${comOf(POSA(3))}`); // right self-loop at 3
+  w.push(`${R(POSM(cols - 1), 'K')}/${comOf(POSA(cols - 1))}`); // right self-loop at the wall
   // (the gated taps for the six real moves are pushed in the legality
   // section, after the rails they route through exist)
   // masters: hold from mid-press through the release window (ANYBM2.G
@@ -1422,11 +1434,11 @@ export function tetrisCircuit(rows = 8): {
   // TWIN.G's chain into the new slave's com, in the window only
   w.push(`${plusOf(ANYBM2)}/${R(ANYBM2, 'H')}`, `${R(ANYBM2, 'G')}/${R(POSA(0), 'L')}`);
   w.push(`${plusOf(TWIN)}/${R(TWIN, 'H')}`, `${R(TWIN, 'G')}/${R(POSA(0), 'H')}`);
-  for (let j = 1; j < 4; j++) {
+  for (let j = 1; j < cols; j++) {
     w.push(`${R(POSA(j - 1), 'L')}/${R(POSA(j), 'L')}`);
     w.push(`${R(POSA(j - 1), 'H')}/${R(POSA(j), 'H')}`);
   }
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < cols; j++) {
     w.push(`${comOf(POSA(j))}/${R(POSA(j), 'E')}`, `${R(POSA(j), 'F')}/${minusOf(POSA(j))}`);
     w.push(`${R(POSA(j), 'K')}/${comOf(POSA(j))}`); // hold: L(chain) -> K -> own com
     w.push(`${R(POSA(j), 'G')}/${comOf(POSS(j))}`); // transfer: H(chain) -> G -> slave com
@@ -1437,17 +1449,16 @@ export function tetrisCircuit(rows = 8): {
   // (both coils die the wave ANYBM2's contacts open), so the idle holds
   // re-close on the same wave the transfer feed dies: the new slave is
   // caught without a gap.
-  w.push(`${R(POSA(3), 'L')}/${R(ANYBM, 'H')}`, `${R(ANYBM, 'J')}/${R(TWIN, 'E')}`, `${R(TWIN, 'F')}/${minusOf(TWIN)}`);
+  w.push(`${R(POSA(cols - 1), 'L')}/${R(ANYBM, 'H')}`, `${R(ANYBM, 'J')}/${R(TWIN, 'E')}`, `${R(TWIN, 'F')}/${minusOf(TWIN)}`);
   // slaves: idle hold through TWIN's NC (closed except in the window) and
   // the POSRST spawn-reset breaks; set2 feeds the PIECE column coils (the
   // slides are gone)
   w.push(`${plusOf(TWIN)}/${R(TWIN, 'L')}`, `${R(TWIN, 'N')}/${R(POSRST(0), 'H')}`);
   w.push(`${R(POSRST(0), 'H')}/${R(POSRST(0), 'L')}`, `${R(POSRST(0), 'L')}/${R(POSRST(1), 'H')}`, `${R(POSRST(1), 'H')}/${R(POSRST(1), 'L')}`);
-  const rstNc: Array<[number, string]> = [
-    [POSRST(0), 'J'], [POSRST(0), 'N'], [POSRST(1), 'J'], [POSRST(1), 'N'],
-  ];
-  for (let j = 0; j < 4; j++) {
-    const [rr, nc] = rstNc[j];
+  // one NC per column: POSRST(0) covers 0-1, POSRST(1) 2-3 (phase C grows)
+  for (let j = 0; j < cols; j++) {
+    const rr = POSRST(Math.floor(j / 2));
+    const nc = j % 2 === 0 ? 'J' : 'N';
     w.push(`${R(rr, nc)}/${R(POSS(j), 'H')}`, `${R(POSS(j), 'G')}/${comOf(POSS(j))}`);
     w.push(`${comOf(POSS(j))}/${R(POSS(j), 'E')}`, `${R(POSS(j), 'F')}/${minusOf(POSS(j))}`);
     w.push(`${comOf(POSS(j))}/${R(POSM(j), 'E')}`, `${R(POSM(j), 'F')}/${minusOf(POSM(j))}`);
@@ -1516,21 +1527,21 @@ export function tetrisCircuit(rows = 8): {
   // from the rail side.
   // grown to 3 base groups in 3b-4b: LTB3 taps the col-3 rail (and the
   // uniform growth leaves room for the coming overhang forms)
-  const legRails = [takeGroups(grown(3, 1)), takeGroups(grown(3, 1)), takeGroups(grown(3, 1)), takeGroups(grown(3, 1))];
+  const legRails = Array.from({ length: cols }, () => takeGroups(grown(3, 1)));
   for (const lg of legRails) for (let i = 1; i < lg.length; i++) w.push(`${lg[i - 1]}/${lg[i]}`);
-  const legUse = [{ n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }];
+  const legUse = Array.from({ length: cols }, () => ({ n: 0 }));
   const legTap = (j: number) => tap(legRails[j], legUse[j]);
   for (let r = 0; r <= rows - 2; r++) {
     const feed0 = r === 0 ? comOf(MIRA(0)) : R(TOPW(r), 'E');
     w.push(`${feed0}/${R(MIRC(r, 0), 'E')}`, `${R(MIRC(r, 0), 'E')}/${R(MIRC(r, 1), 'E')}`);
     w.push(`${R(MIRC(r, 0), 'F')}/${minusOf(MIRC(r, 0))}`, `${R(MIRC(r, 1), 'F')}/${minusOf(MIRC(r, 1))}`);
-    for (let j = 0; j < 4; j++) {
-      const mr = MIRC(r, j < 2 ? 0 : 1);
+    for (let j = 0; j < cols; j++) {
+      const mr = MIRC(r, Math.floor(j / 2));
       const [arm, no] = j % 2 === 0 ? ['H', 'G'] : ['L', 'K'];
       w.push(`${comOf(CELL(r, j))}/${R(mr, arm)}`, `${R(mr, no)}/${legTap(j)}`);
     }
   }
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < cols; j++) {
     w.push(`${legTap(j)}/${R(LEGINV(j), 'E')}`, `${R(LEGINV(j), 'F')}/${minusOf(LEGINV(j))}`);
   }
   // second reads of columns 2 and 3 (parallel coils, coil-jack chained)
@@ -1550,18 +1561,18 @@ export function tetrisCircuit(rows = 8): {
   // pieces, no-token steering and the power-on ring never feel this bank.
   // grown to 3 base groups in 3b-3b: the mode-gated coil feeds (NOT-Z /
   // NOT-S gates + the LTS/LTZ reads) add two taps per column
-  const legTRails = [takeGroups(grown(3, 1)), takeGroups(grown(3, 1)), takeGroups(grown(3, 1)), takeGroups(grown(3, 1))];
+  const legTRails = Array.from({ length: cols }, () => takeGroups(grown(3, 1)));
   for (const lg of legTRails) for (let i = 1; i < lg.length; i++) w.push(`${lg[i - 1]}/${lg[i]}`);
-  const legTUse = [{ n: 0 }, { n: 0 }, { n: 0 }, { n: 0 }];
+  const legTUse = Array.from({ length: cols }, () => ({ n: 0 }));
   const legTTap = (j: number) => tap(legTRails[j], legTUse[j]);
   for (let r = 1; r <= rows - 2; r++) {
     w.push(`${R(MIRC(r, 1), 'E')}/${R(MIRCT(r, 0), 'E')}`, `${R(MIRCT(r, 0), 'E')}/${R(MIRCT(r, 1), 'E')}`);
     w.push(`${R(MIRCT(r, 0), 'F')}/${minusOf(MIRCT(r, 0))}`, `${R(MIRCT(r, 1), 'F')}/${minusOf(MIRCT(r, 1))}`);
-    for (let j = 0; j < 4; j++) {
+    for (let j = 0; j < cols; j++) {
       const armPrev = j % 2 === 0 ? 'H' : 'L';
-      const mt = MIRCT(r, j < 2 ? 0 : 1);
+      const mt = MIRCT(r, Math.floor(j / 2));
       const [arm, no] = j % 2 === 0 ? ['H', 'G'] : ['L', 'K'];
-      w.push(`${R(MIRC(r - 1, j < 2 ? 0 : 1), armPrev)}/${R(mt, arm)}`, `${R(mt, no)}/${legTTap(j)}`);
+      w.push(`${R(MIRC(r - 1, Math.floor(j / 2)), armPrev)}/${R(mt, arm)}`, `${R(mt, no)}/${legTTap(j)}`);
     }
   }
   // 3b-3b: the top-bank coils are MODE-GATED at the feed — LEGINVT
@@ -1572,8 +1583,8 @@ export function tetrisCircuit(rows = 8): {
   // so the tree shapes below stay EXACTLY as they were. Legacy slide-
   // staggered mode (STAG up, no ring state) keeps the old symmetric
   // checks, unchanged.
-  for (let j = 0; j < 4; j++) {
-    const zg = ZG(j < 2 ? 0 : 1);
+  for (let j = 0; j < cols; j++) {
+    const zg = ZG(Math.floor(j / 2));
     const [zArm, zNc] = j % 2 === 0 ? ['H', 'J'] : ['L', 'N'];
     w.push(`${legTTap(j)}/${R(zg, zArm)}`, `${R(zg, zNc)}/${R(LEGINVT(j), 'E')}`);
     w.push(`${R(LEGINVT(j), 'F')}/${minusOf(LEGINVT(j))}`);
@@ -1583,8 +1594,8 @@ export function tetrisCircuit(rows = 8): {
   // vmode mirrors for the tall forks (VMODE's own spare set can't serve
   // six tap trees); coils daisy-chained through the coil jacks
   w.push(`${R(VMODE, 'E')}/${R(VMODEM(0), 'E')}`);
-  for (let p = 1; p < 4; p++) w.push(`${R(VMODEM(p - 1), 'E')}/${R(VMODEM(p), 'E')}`);
-  for (let p = 0; p < 4; p++) w.push(`${R(VMODEM(p), 'F')}/${minusOf(VMODEM(p))}`);
+  for (let p = 1; p < cols; p++) w.push(`${R(VMODEM(p - 1), 'E')}/${R(VMODEM(p), 'E')}`);
+  for (let p = 0; p < cols; p++) w.push(`${R(VMODEM(p), 'F')}/${minusOf(VMODEM(p))}`);
 
   // the gated D-taps: every stage is a CHANGEOVER (blocked returns the
   // sample to the current master — see the ring notes) and every OPTIONAL
@@ -1871,10 +1882,10 @@ export function tetrisCircuit(rows = 8): {
   w.push(`${R(CUTB3, 'F')}/${minusOf(CUTB3)}`, `${R(CUTB4, 'F')}/${minusOf(CUTB4)}`);
   w.push(`${R(CUTC5, 'F')}/${minusOf(CUTC5)}`, `${R(CUTC6, 'F')}/${minusOf(CUTC6)}`);
   w.push(`${R(CUTB1, 'F')}/${minusOf(CUTB1)}`, `${R(CUTB2, 'F')}/${minusOf(CUTB2)}`);
-  for (let j = 0; j < 4; j++) {
+  for (let j = 0; j < cols; j++) {
     const pt = PIECET(j);
     w.push(`${bmS}.${j + 1}+/${bmS}.${j + 1}S`, `${bmS}.${j + 1}T/${R(pt, 'E')}`, `${R(pt, 'F')}/${minusOf(pt)}`);
-    const cutc = j < 2 ? CUTC5 : CUTC6;
+    const cutc = [CUTC5, CUTC6][Math.floor(j / 2)]; // phase C grows the bank
     const [cArm, cNo] = j % 2 === 0 ? ['H', 'G'] : ['L', 'K'];
     w.push(`${colFanT}/${R(cutc, cArm)}`, `${R(cutc, cNo)}/${R(pt, 'H')}`);
     w.push(`${R(pt, 'G')}/${tapRail(j)}`);
@@ -1893,10 +1904,12 @@ export function tetrisCircuit(rows = 8): {
   // can never read occupied at the token row. Branch pairs tie at the
   // LEGB output jacks to fit collideNode's hole budget; a backward walk
   // from the node dead-ends at + or an open contact in every state.
-  for (let j = 0; j < 4; j++) {
-    const feed =
-      j === 0 ? R(LEGINV(0), 'E') : j === 1 ? R(LEGINV(1), 'E') : j === 2 ? R(LEGINV2(2), 'E') : R(LEGINV2(3), 'E');
-    w.push(`${feed}/${R(LEGB(j), 'E')}`, `${R(LEGB(j), 'F')}/${minusOf(LEGB(j))}`);
+  // occupied() feeds per column — a CLASS map: 0,1 read LEGINV directly,
+  // 2,3 the LEGINV2 parallel copies (LEGINV(2/3)'s sets are spent). phase
+  // C re-derives which columns need copies at a wider well.
+  const legbFeed = [R(LEGINV(0), 'E'), R(LEGINV(1), 'E'), R(LEGINV2(2), 'E'), R(LEGINV2(3), 'E')];
+  for (let j = 0; j < cols; j++) {
+    w.push(`${legbFeed[j]}/${R(LEGB(j), 'E')}`, `${R(LEGB(j), 'F')}/${minusOf(LEGB(j))}`);
     w.push(`${plusOf(PIECET(j))}/${R(PIECET(j), 'L')}`, `${R(PIECET(j), 'K')}/${R(LEGB(j), 'H')}`);
   }
   // branch outputs chain jack-to-jack and enter at COLLIDE's com (its one

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -199,6 +199,32 @@ export const ZG = (k: number) => 389 + k; // Z mirrors: ZG(0,1) = NOT-Z coil gat
 // them; position first, then reshape: the transition network gates the
 // entry at pos {0,1} and reads the delta cells).
 export const NSTATES = 12; // ring states (the page's cycle length)
+// the shape set — geometry per ring state as (bottom offset/width, top
+// offset/width): the bottom row sits at register position p+bOff, the
+// top at p+tOff. Order MUST match the ring (the L/J/T triples appended
+// in 3b-4a, their 180-degree overhang forms in 3b-4c). SINGLE SOURCE OF
+// TRUTH: the page renders from it and the wider-well emitter derives
+// its step/reshape check tables from it (_notes/wider-well.md).
+export const SHAPES = [
+  { label: '1x1', bOff: 0, bW: 1, tOff: 0, tW: 0 },
+  { label: '2 wide', bOff: 0, bW: 2, tOff: 0, tW: 0 },
+  { label: '2 tall', bOff: 0, bW: 1, tOff: 0, tW: 1 },
+  { label: '2x2 square', bOff: 0, bW: 2, tOff: 0, tW: 2 },
+  { label: 'S', bOff: 0, bW: 2, tOff: -1, tW: 2 },
+  { label: 'Z', bOff: 0, bW: 2, tOff: 1, tW: 2 },
+  { label: 'L', bOff: 0, bW: 3, tOff: 0, tW: 1 },
+  { label: 'J', bOff: 0, bW: 3, tOff: 2, tW: 1 },
+  { label: 'T', bOff: 0, bW: 3, tOff: 1, tW: 1 },
+  { label: 'L flip', bOff: 2, bW: 1, tOff: 0, tW: 3 },
+  { label: 'J flip', bOff: 0, bW: 1, tOff: 0, tW: 3 },
+  { label: 'T flip', bOff: 1, bW: 1, tOff: 0, tW: 3 },
+] as const;
+if (SHAPES.length !== NSTATES) throw new Error('SHAPES must mirror the ring');
+// legal register positions for a shape at a given width (both rows fit)
+export const shapeRange = (s: (typeof SHAPES)[number], cols: number) => ({
+  min: Math.max(0, -s.bOff, s.tW > 0 ? -s.tOff : 0),
+  max: Math.min(cols - s.bOff - s.bW, s.tW > 0 ? cols - s.tOff - s.tW : cols),
+});
 export const SHR2 = (i: number, part: number) => 415 + 3 * (i - 6) + part; // states 6..8: clk, master, slave (415..423)
 export const MMIR2 = (i: number) => 424 + (i - 6); // into-6..8 transition gates (424..426)
 // POSM5 set map (7 pos0 + 7 pos1 uses): k=0 B-fan PIECE(2) + T-fan L1;

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -1605,7 +1605,8 @@ export function tetrisCircuit(rows = 8, cols = 4): {
     // T2/L2 bottom reads + every left tree's d0 bypass changeovers) grow
     // with cols: L2 = 4 members + (cols-1) bypasses + (cols-3) reads,
     // T2 = 4 + (cols-1) + (cols-1), S = 4 + (cols-2), J1 = 3 + (cols-2)
-    const caps = [1, 1, 2, 2, Math.ceil((cols + 2) / 2), 2, 2, Math.ceil((cols + 1) / 2), 2, cols + 1, 2, cols + 2];
+    // state 0 (1x1) also anchors the LEGACY pairs: five more sets
+    const caps = [3, 1, 2, 2, Math.ceil((cols + 2) / 2), 2, 2, Math.ceil((cols + 1) / 2), 2, cols + 1, 2, cols + 2];
     let off = 0;
     for (let i = 0; i < NSTATES; i++) {
       stBanks.push(
@@ -1619,7 +1620,10 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // jack to jack, ONE wire enters the coil net — the LEGB trick)
   let stpUnionN = 0;
   let stpUGateOff = 0;
-  const mkUnion = (name: string, members: number[]) => {
+  // an extra member can be a SERIES chain of contacts (all must conduct):
+  // the legacy slide modes join as pairs — mode relay AND ring-at-1x1
+  type SeriesMember = Array<{ relay: number; arm: string; no: string }>;
+  const mkUnion = (name: string, members: number[], extras: SeriesMember[] = []) => {
     if (stpUnionN >= L.STPUNION_CAP) throw new Error('union rails overflow');
     const u = L.STPUNION + stpUnionN++;
     let prev: string | null = null;
@@ -1628,6 +1632,15 @@ export function tetrisCircuit(rows = 8, cols = 4): {
       w.push(`${plusOf(cs.relay)}/${R(cs.relay, cs.arm)}`);
       if (prev !== null) w.push(`${prev}/${R(cs.relay, cs.no)}`);
       prev = R(cs.relay, cs.no);
+    }
+    for (const chain of extras) {
+      let feed: string | null = null;
+      for (const cs of chain) {
+        w.push(`${feed === null ? plusOf(cs.relay) : feed}/${R(cs.relay, cs.arm)}`);
+        feed = R(cs.relay, cs.no);
+      }
+      if (prev !== null) w.push(`${prev}/${feed as string}`);
+      prev = feed;
     }
     w.push(`${prev}/${R(u, 'E')}`, `${R(u, 'F')}/${minusOf(u)}`);
     const gateCap = Math.ceil((cols - 1) / 2) + 1;
@@ -1638,16 +1651,34 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   };
   // state indices by ring order (SHAPES): 0 1x1, 1 2wide, 2 2tall, 3 O,
   // 4 S, 5 Z, 6 L1, 7 J1, 8 T1, 9 L2, 10 J2, 11 T2
+  // the LEGACY slide modes (ring parked at 1x1) ride as series pairs on
+  // the retired fork relays' free sets — WIDM3/VMODEM parallel the
+  // slide-or-ring compatibility nets, so (fork AND 1x1) = slide-driven:
+  const leg1x1 = () => {
+    const cs = stBanks[0].request('gate');
+    return { relay: cs.relay, arm: cs.arm, no: cs.no };
+  };
   const uB0 = mkUnion('B0', [0, 2, 10]); // right bottom d0
-  const uB1 = mkUnion('B1', [1, 3, 4, 5, 11]); // right bottom d1
+  const uB1 = mkUnion('B1', [1, 3, 4, 5, 11], [
+    [{ relay: WIDM3, arm: 'H', no: 'G' }, leg1x1()], // legacy wide
+  ]); // right bottom d1
   const uB2 = mkUnion('B2', [6, 7, 8, 9]); // right bottom d2
-  const uT0 = mkUnion('T0', [2, 4, 6]); // right top d0
-  const uT1 = mkUnion('T1', [3, 8]); // right top d1
+  const uT0 = mkUnion('T0', [2, 4, 6], [
+    [{ relay: VMODEM(0), arm: 'H', no: 'G' }, leg1x1()], // legacy tall
+  ]); // right top d0
+  const uT1 = mkUnion('T1', [3, 8], [
+    // the legacy 2x2 (tall AND wide slides): top delta is c+1
+    [{ relay: VMODEM(1), arm: 'H', no: 'G' }, { relay: WIDM4, arm: 'H', no: 'G' }, leg1x1()],
+  ]); // right top d1
   const uT2 = mkUnion('T2', [5, 7, 9, 10, 11]); // right top d2
-  const uT0L = mkUnion('T0L', [2, 3, 6, 9, 10, 11]); // left top d0
+  const uT0L = mkUnion('T0L', [2, 3, 6, 9, 10, 11], [
+    [{ relay: VMODEM(0), arm: 'L', no: 'K' }, leg1x1()], // legacy tall, left
+  ]); // left top d0
   const uT1L = mkUnion('T1L', [5, 8]); // left top d1
   const uHIB = mkUnion('HIB', [5, 6, 7, 8, 9, 10, 11]); // max == cols-3
-  const uWALLB = mkUnion('WALLB', [1, 3, 4]); // max == cols-2
+  const uWALLB = mkUnion('WALLB', [1, 3, 4], [
+    [{ relay: WIDM3, arm: 'L', no: 'K' }, leg1x1()], // legacy wide wall
+  ]); // max == cols-2
   const stpPool = new GatedReadPool({ name: 'STPREAD', source: null, base: L.STPREAD, capacity: L.STPREAD_CAP, w, R, minusOf });
   // refusal returns per SOURCE column, on matrix groups into the master
   const retNode = Array.from({ length: cols }, () => takeGroups(4)); // ~15 refusal taps/source peak (width-invariant)

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -17,7 +17,8 @@
  * list is the compiled output.
  */
 
-import { MirrorBank } from './contact-alloc';
+import { GatedReadPool, MirrorBank } from './contact-alloc';
+import type { ContactSet } from './contact-alloc';
 
 // ---- relay allocation: relay n lives at machine floor(n/6), section n%6+1
 export const R = (n: number, jack: string) => `m${Math.floor(n / 6)}.${(n % 6) + 1}${jack}`;
@@ -422,6 +423,10 @@ export interface TetrisLayout {
   LTOT: number; LTOB: (k: number) => number; T2B: (k: number) => number;
   UTR3: number; LEGB3: (k: number) => number; POSM6: (k: number) => number;
   TOSC: number; TDRV: number;
+  STPMIR: number; STPMIR_CAP: number;
+  STPUNION: number; STPUNION_CAP: number;
+  STPUGATE: number; STPUGATE_CAP: number;
+  STPREAD: number; STPREAD_CAP: number;
   btnMachine: number; // the dedicated (relay-free) button/slide machine
   machines: number;
   relays: number; // wired coils (the junction gap is com-only)
@@ -499,6 +504,13 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   const shr3Base = take(9); // 3b-4c: states 9..11 (L2, J2, T2)
   const g4cBase = take(33); // MMIR3 x3, TT+TTM x6, BCUT x2, L2M x3, J2M, T2M x3, LTOT, LTOB x2, T2B x2, UTR3, LEGB3 x3, POSM6 x6
   const oscBase = take(2); // 3b-5: TOSC, TDRV (the self-tick oscillator)
+  // ---- the wider-well step-tree emitter's banks (uniform union-gated
+  // trees; the hand-laid tree support banks above go dead-unwired) ----
+  // caps are generous formula bounds; the emitter asserts actual <= cap
+  const stpMirBase = take(40 + 6 * (cols - 1)); // per-state member + singleton-gate mirrors
+  const stpUnionBase = take(10); // the union rails (B0..WALLB)
+  const stpUGateBase = take(12 * (cols - 1)); // union mirrors: per-tree gate contacts
+  const stpReadBase = take(8 * (cols - 1)); // the gated read pool
   return {
     rows,
     cols,
@@ -575,6 +587,10 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
     LTOT: g4cBase + 18, LTOB: k => g4cBase + 19 + k, T2B: k => g4cBase + 21 + k,
     UTR3: g4cBase + 23, LEGB3: k => g4cBase + 24 + k, POSM6: k => g4cBase + 27 + k,
     TOSC: oscBase, TDRV: oscBase + 1,
+    STPMIR: stpMirBase, STPMIR_CAP: 40 + 6 * (cols - 1),
+    STPUNION: stpUnionBase, STPUNION_CAP: 10,
+    STPUGATE: stpUGateBase, STPUGATE_CAP: 12 * (cols - 1),
+    STPREAD: stpReadBase, STPREAD_CAP: 8 * (cols - 1),
     btnMachine: Math.ceil(n / 6),
     machines: Math.ceil(n / 6) + 1,
     relays: n - (rows - 3),
@@ -673,6 +689,10 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   claim('LEGB3', LEGB3(0), LEGB3(1), LEGB3(2));
   for (let k = 0; k < 6; k++) claim('POSM6', POSM6(k));
   claim('TOSC/TDRV', TOSC, TDRV);
+  for (let k = 0; k < L8.STPMIR_CAP; k++) claim('STPMIR', L8.STPMIR + k);
+  for (let k = 0; k < L8.STPUNION_CAP; k++) claim('STPUNION', L8.STPUNION + k);
+  for (let k = 0; k < L8.STPUGATE_CAP; k++) claim('STPUGATE', L8.STPUGATE + k);
+  for (let k = 0; k < L8.STPREAD_CAP; k++) claim('STPREAD', L8.STPREAD + k);
 
 }
 
@@ -695,15 +715,15 @@ export function tetrisCircuit(rows = 8, cols = 4): {
     ELEVW1, ELEVW2, CGA, CGB, CGB2, CUTC1, CUTC2, JUNC,
     TG2M, TG2S, CUTC3, CUTC4,
     POSA, POSS, POSM, LEFTM, RIGHTM, ANYBM, ANYBM2, WIDM, WIDM2,
-    POSRST, TWIN, BOOTL, POSM2, MIRC, LEGINV, LEGINV2, WIDM3, WIDM4,
-    MIRCT, LEGINVT, LEGINVT2, VMODEM, GOM, GAMEOVER, LKM2, SCR, SCBOOT, PIECET, CUTC5, CUTC6, STAGM, CUTB1, CUTB2, CUTB3, CUTB4, CUTBD, LEGB, STAGM2,
+    POSRST, TWIN, BOOTL, POSM2, MIRC, LEGINV, WIDM3, WIDM4,
+    MIRCT, LEGINVT, VMODEM, GOM, GAMEOVER, LKM2, SCR, SCBOOT, PIECET, CUTC5, CUTC6, STAGM, CUTB1, CUTB2, CUTB3, CUTB4, CUTBD, LEGB, STAGM2,
     SHR, UPM, SHBOOT, SM, ZM, OM, I2TM, I2WM, POSM3,
-    LTS, LTZ, SG, ZG,
+    SG, ZG,
     MMIR, POSM4, LEGB2, UTR,
     SHR2, MMIR2, POSM5, UTR2, TRP, TRPM, L1M, J1M, T1M, WID3M,
-    ZJT, SLJ, ZM2, SM2, J1M2, J1M3, T1M2, LTJ, LTT, LTB3,
+    ZJT, SLJ, ZM2, SM2, J1M2, J1M3, T1M2,
     SHR3, MMIR3, TT, TTM, BCUT, BCUTM, L2M, J2M, T2M,
-    LTOT, LTOB, T2B, UTR3, LEGB3, POSM6,
+    UTR3, LEGB3, POSM6,
     TOSC, TDRV,
   } = L;
   // buttons/slides live on the layout's dedicated relay-free machine:
@@ -1502,10 +1522,8 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   for (let j = 0; j < cols; j++) {
     w.push(`${legTap(j)}/${R(LEGINV(j), 'E')}`, `${R(LEGINV(j), 'F')}/${minusOf(LEGINV(j))}`);
   }
-  // second reads of columns 2 and 3 (parallel coils, coil-jack chained)
-  // for the wide right-edge checks — LEGINV's own sets are spoken for
-  w.push(`${R(LEGINV(2), 'E')}/${R(LEGINV2(2), 'E')}`, `${R(LEGINV2(2), 'F')}/${minusOf(LEGINV2(2))}`);
-  w.push(`${R(LEGINV(3), 'E')}/${R(LEGINV2(3), 'E')}`, `${R(LEGINV2(3), 'F')}/${minusOf(LEGINV2(3))}`);
+  // (LEGINV2 — the hand-laid wide-fork copies — retired by the uniform
+  // step trees below: off-column reads come from the gated read pool)
   // narrow/wall mirrors on the WID slide (WIDM/WIDM2's sets feed PIECE)
   w.push(`${R(WIDM, 'E')}/${R(WIDM3, 'E')}`, `${R(WIDM3, 'F')}/${minusOf(WIDM3)}`);
   w.push(`${R(WIDM2, 'E')}/${R(WIDM4, 'E')}`, `${R(WIDM4, 'F')}/${minusOf(WIDM4)}`);
@@ -1541,208 +1559,180 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // so the tree shapes below stay EXACTLY as they were. Legacy slide-
   // staggered mode (STAG up, no ring state) keeps the old symmetric
   // checks, unchanged.
+  // the top-row occupancy reads LEGINVT(j) go PLAIN now (the old NOT-Z
+  // coil gates retired — the uniform trees gate the SAMPLE PATH through
+  // union contacts instead, so a dead union's NC passes the sample and
+  // the coil can stay honest occupancy). LEGINVT2 retired with them.
   for (let j = 0; j < cols; j++) {
-    const zg = ZG(Math.floor(j / 2));
-    const [zArm, zNc] = j % 2 === 0 ? ['H', 'J'] : ['L', 'N'];
-    w.push(`${legTTap(j)}/${R(zg, zArm)}`, `${R(zg, zNc)}/${R(LEGINVT(j), 'E')}`);
+    w.push(`${legTTap(j)}/${R(LEGINVT(j), 'E')}`);
     w.push(`${R(LEGINVT(j), 'F')}/${minusOf(LEGINVT(j))}`);
   }
-  w.push(`${legTTap(2)}/${R(SG(0), 'H')}`, `${R(SG(0), 'J')}/${R(LEGINVT2(2), 'E')}`, `${R(LEGINVT2(2), 'F')}/${minusOf(LEGINVT2(2))}`);
-  w.push(`${legTTap(3)}/${R(SG(0), 'L')}`, `${R(SG(0), 'N')}/${R(LEGINVT2(3), 'E')}`, `${R(LEGINVT2(3), 'F')}/${minusOf(LEGINVT2(3))}`);
-  // vmode mirrors for the tall forks (VMODE's own spare set can't serve
-  // six tap trees); coils daisy-chained through the coil jacks
-  // ...as the first allocator-managed bank (wider-well emitter 0 pilot):
-  // the bank mints the same chain lazily; requests below arrive in the
-  // hand-laid order, so the set map is unchanged (wire-multiset gate).
-  // NOTE the chain tail stays a splice point: the ring-state union
-  // enters at VMODEM(cols-1).E's free hole (the 3b-4a/4c splices).
-  const vmBank = new MirrorBank({
-    name: 'VMODEM', source: VMODE, base: VMODEM(0), capacity: cols, w, R, minusOf,
-  });
+  // the VMODEM chain stays WIRED (its contacts are unused since the
+  // uniform trees, but the coil net IS the tall compatibility-OR: the
+  // slide feeds VMODE.E and the ring-state tall union splices in at
+  // VMODEM(cols-1).E — see the 3b-4a/4c splices)
+  w.push(`${R(VMODE, 'E')}/${R(VMODEM(0), 'E')}`);
+  for (let p = 1; p < cols; p++) w.push(`${R(VMODEM(p - 1), 'E')}/${R(VMODEM(p), 'E')}`);
+  for (let p = 0; p < cols; p++) w.push(`${R(VMODEM(p), 'F')}/${minusOf(VMODEM(p))}`);
 
-  // the gated D-taps: every stage is a CHANGEOVER (blocked returns the
-  // sample to the current master — see the ring notes) and every OPTIONAL
-  // stage is a mode fork. RIGHT into c (c=1,2):
-  //   LEGINV(c) {occ->ret; free-> VMODEM {flat->X; tall-> LEGINVT(c)
-  //   {occ->ret; free->X}}}; X -> WIDM3 {narrow->step; wide-> LEGINV2(c+1)
-  //   {occ->ret; free-> VMODEM' {flat->step; tall-> LEGINVT2(c+1)
-  //   {occ->ret; free->step}}}}
-  // RIGHT into 3: LEGINV(3) -> tall fork -> WIDM4 {narrow->step;
-  // wide->ret} — the wall. LEFT into c (c=0,1,2): LEGINV(c) -> tall fork
-  // -> step (a wide piece's right cell moves into its own old column, so
-  // left needs no wide stage). Refusal returns collect on matrix groups
-  // (two chained for the both-direction positions) and re-latch the
-  // current master through its coil jack's spare hole.
-  // return groups grown in 3b-3b (the mode hops add refusal throws; the
-  // old hand-split 1/2/2 chains overflowed the moment they grew) and
-  // again in 3b-4b (the triple legs): a uniform tap allocator
-  const retNode = [takeGroups(3), takeGroups(5), takeGroups(4)];
-  for (const g of retNode) for (let i = 1; i < g.length; i++) w.push(`${g[i - 1]}/${g[i]}`);
-  const retUse = [{ n: 0 }, { n: 0 }, { n: 0 }];
-  const retTap = (p: number) => tap(retNode[p], retUse[p]);
-  w.push(`${retTap(0)}/${R(POSA(0), 'E')}`);
-  w.push(`${retTap(1)}/${R(POSA(1), 'E')}`);
-  w.push(`${retTap(2)}/${R(POSA(2), 'E')}`);
-  for (const c of [1, 2] as const) {
-    const tf = vmBank.request('changeover'); // the tall fork
-    const tw = vmBank.request('changeover'); // the tall-wide fork
-    const [wArm, wNc, wNo] = c === 1 ? ['H', 'J', 'G'] : ['L', 'N', 'K'];
-    if (c === 1) {
-      // 3b-4c: the OVR bypass — LEGINV(c) false-refuses L2/T2 (their
-      // target bottoms exclude column c), so the overhang states route
-      // AROUND the bottom check straight to the tall fork; their true
-      // bottom columns read as gated hops further down
-      w.push(`${R(POSM(0), 'K')}/${R(BCUTM, 'H')}`);
-      w.push(`${R(BCUTM, 'J')}/${R(LEGINV(1), 'H')}`);
-      w.push(`${R(BCUTM, 'G')}/${R(tf.relay, tf.arm)}`); // overhang: skip to the fork
-    } else {
-      w.push(`${R(POSM(c - 1), 'K')}/${R(LEGINV(c), 'H')}`); // the tap in
-    }
-    w.push(`${R(LEGINV(c), 'G')}/${retTap(c - 1)}`); // bottom-c occupied
-    w.push(`${R(LEGINV(c), 'J')}/${R(tf.relay, tf.arm)}`); // free: the tall fork
-    w.push(`${R(tf.relay, tf.no)}/${R(LEGINVT(c), 'H')}`); // tall: check top-c
-    w.push(`${R(LEGINVT(c), 'G')}/${retTap(c - 1)}`); // top-c occupied
-    // 3b-3b: S's extra top column (c-1) rides IN SERIES — under any other
-    // mode the LTS coil is dead and its NC passes through. For c=2 the Z
-    // BOUND follows: Z cannot enter pos 2, so ZG(3)'s NO (closed iff the
-    // Z state is up) returns the sample unconditionally.
-    if (c === 1) {
-      w.push(`${R(LEGINVT(1), 'J')}/${R(LTS(0), 'H')}`);
-      w.push(`${R(LTS(0), 'G')}/${retTap(0)}`); // S: top-0 occupied
-      // 3b-4b: J1's stem target (top col 3) and the triple bottom's
-      // entering column (bottom col 3) ride behind the S hop; T1's
-      // target (top col 2) is the existing point-2 check, for free
-      w.push(`${R(LTS(0), 'J')}/${R(LTJ(1), 'H')}`);
-      w.push(`${R(LTJ(1), 'G')}/${retTap(0)}`); // J1: top-3 occupied
-      w.push(`${R(LTJ(1), 'J')}/${R(LTB3, 'H')}`);
-      w.push(`${R(LTB3, 'G')}/${retTap(0)}`); // triple: bottom-3 occupied
-      // 3b-4c: the overhangs' entering top col 3 (TT-gated) and L2's
-      // entering bottom col 3 (T2's rides the wide fork's existing check)
-      w.push(`${R(LTB3, 'J')}/${R(LTOT, 'H')}`);
-      w.push(`${R(LTOT, 'G')}/${retTap(0)}`); // TT: top-3 occupied
-      w.push(`${R(LTOT, 'J')}/${R(LTOB(1), 'H')}`);
-      w.push(`${R(LTOB(1), 'G')}/${retTap(0)}`); // L2: bottom-3 occupied
-      w.push(`${R(LTOB(1), 'J')}/${R(tf.relay, tf.nc)}`); // free: join X
-    } else {
-      w.push(`${R(LEGINVT(2), 'J')}/${R(LTS(1), 'H')}`);
-      w.push(`${R(LTS(1), 'G')}/${retTap(1)}`); // S: top-1 occupied
-      w.push(`${R(LTS(1), 'J')}/${R(ZG(3), 'L')}`);
-      w.push(`${R(ZG(3), 'K')}/${retTap(1)}`); // the Z bound: refuse
-      // 3b-4b/4c: the triple bounds — neither a 3-wide bottom (TRP) nor
-      // a 3-wide top (TT) can enter pos 2
-      w.push(`${R(ZG(3), 'N')}/${R(TRPM(1), 'L')}`);
-      w.push(`${R(TRPM(1), 'K')}/${retTap(1)}`);
-      w.push(`${R(TRPM(1), 'N')}/${R(TTM(4), 'L')}`);
-      w.push(`${R(TTM(4), 'K')}/${retTap(1)}`);
-      w.push(`${R(TTM(4), 'N')}/${R(tf.relay, tf.nc)}`); // free: join X
-    }
-    w.push(`${R(tf.relay, tf.nc)}/${R(WIDM3, wArm)}`); // X: the wide fork
-    w.push(`${R(WIDM3, wNc)}/${comOf(POSA(c))}`); // narrow: step
-    w.push(`${R(WIDM3, wNo)}/${R(LEGINV2(c + 1), 'H')}`); // wide: bottom-c+1
-    w.push(`${R(LEGINV2(c + 1), 'G')}/${retTap(c - 1)}`); // occupied
-    w.push(`${R(LEGINV2(c + 1), 'J')}/${R(tw.relay, tw.arm)}`); // free: tall fork #2
-    w.push(`${R(tw.relay, tw.nc)}/${R(WIDM3, wNc)}`); // flat-wide: join the step wire
-    w.push(`${R(tw.relay, tw.no)}/${R(LEGINVT2(c + 1), 'H')}`); // tall-wide: top-c+1
-    w.push(`${R(LEGINVT2(c + 1), 'G')}/${retTap(c - 1)}`); // occupied
-    // 3b-3b: Z's extra top column (c+2) — only c=1 has one on the board
-    // (c=2's Z was already returned by the bound at point 1)
-    if (c === 1) {
-      w.push(`${R(LEGINVT2(2), 'J')}/${R(LTZ(2), 'H')}`);
-      w.push(`${R(LTZ(2), 'G')}/${retTap(0)}`); // Z: top-3 occupied
-      w.push(`${R(LTZ(2), 'J')}/${R(tw.relay, tw.nc)}`); // free: join
-    } else {
-      w.push(`${R(LEGINVT2(3), 'J')}/${R(tw.relay, tw.nc)}`); // free: join
-    }
-  }
-  const wallTf = vmBank.request('changeover'); // VMODEM(2).set1, hand order
-  w.push(`${R(POSM(2), 'K')}/${R(LEGINV(3), 'H')}`);
-  w.push(`${R(LEGINV(3), 'G')}/${retTap(2)}`); // bottom-3 occupied
-  w.push(`${R(LEGINV(3), 'J')}/${R(wallTf.relay, wallTf.arm)}`); // free: the tall fork
-  w.push(`${R(wallTf.relay, wallTf.no)}/${R(LEGINVT(3), 'H')}`); // tall: top-3
-  w.push(`${R(LEGINVT(3), 'G')}/${retTap(2)}`); // occupied
-  w.push(`${R(LEGINVT(3), 'J')}/${R(wallTf.relay, wallTf.nc)}`); // free: join
-  w.push(`${R(wallTf.relay, wallTf.nc)}/${R(WIDM4, 'H')}`); // the wall gate
-  w.push(`${R(WIDM4, 'J')}/${comOf(POSA(3))}`); // narrow: step
-  w.push(`${R(WIDM4, 'G')}/${retTap(2)}`); // wide: the wall, return
-  // left taps: the tall fork sets — requested in the hand-laid order
-  // (VMODEM(2).set2 into 0, then VMODEM(3)'s two sets into 1 and 2)
-  const leftFork = [
-    vmBank.request('changeover'), // into 0
-    vmBank.request('changeover'), // into 1
-    vmBank.request('changeover'), // into 2
+  // ---------- the step trees: uniform union-gated (wider-well C) ------
+  // "buttons request, contacts decide" as ever, but the trees are EMITTED
+  // now: every check is a rail read gated by a UNION of the states it
+  // applies to, wired in series — a dead union's NC passes the sample
+  // through, so each state feels exactly its own entering-cell checks
+  // (stepEntering) and nothing else. bound refusals come FIRST in each
+  // chain (width-invariant: the wall refuses {2wide,O,S}, the second-
+  // to-wall refuses {Z, triples, overhangs}, left-into-0 refuses S),
+  // reads outside the well CLIP (their members are bound-refused before
+  // them), and refusals return the sample into the current master's
+  // coil (the forced no-op step, as before). d0 reads reuse LEGINV /
+  // LEGINVT contacts path-gated by union contacts; off-column reads are
+  // pool relays coil-gated (rail AND union). the mode-fork optimization
+  // of the hand-laid trees is gone on purpose: uniformity is what makes
+  // the width a parameter.
+  // per-state mirror banks chain off each state's EXISTING mirror-chain
+  // TAIL (the slave coil jacks are full: com/E + the 3b chains); state 0
+  // never had mirrors, so its slave E has the one free hole
+  const mirrorTailOf = [
+    SHR(0, 2), I2WM, I2TM, OM, SM2, ZG(3),
+    L1M(1), J1M3, T1M2, L2M(2), J2M, T2M(2),
   ];
-  // 3b-3b: each left tree's tall path gains its mode hops in series after
-  // the (NOT-Z-gated) symmetric check: the S bound (left into 0 is out of
-  // S's fit range) or S's extra column c-1, then Z's true target columns
-  // c+1 / c+2 (dead coils pass through; left into 2 clips c+2 = 4).
-  for (const c of [0, 1, 2] as const) {
-    const { relay: vm, arm: vArm, nc: vNc, no: vNo } = leftFork[c];
-    if (c === 0) {
-      // 3b-4c: the OVR bypass (see the right tree) — L2/T2 skip the
-      // false bottom check; their true columns read further down
-      w.push(`${R(POSM(1), 'G')}/${R(BCUT, 'L')}`);
-      w.push(`${R(BCUT, 'N')}/${R(LEGINV(0), 'L')}`);
-      w.push(`${R(BCUT, 'K')}/${R(vm, vArm)}`); // overhang: skip to the fork
-    } else if (c === 1) {
-      w.push(`${R(POSM(2), 'G')}/${R(BCUTM, 'L')}`);
-      w.push(`${R(BCUTM, 'N')}/${R(LEGINV(1), 'L')}`);
-      w.push(`${R(BCUTM, 'K')}/${R(vm, vArm)}`); // overhang: skip to the fork
-    } else {
-      w.push(`${R(POSM(c + 1), 'G')}/${R(LEGINV(c), 'L')}`); // the tap in
+  const stBanks: MirrorBank[] = [];
+  {
+    // sets per state: memberships (width-invariant) + per-tree singles
+    // (S/J1 top reads, T2/L2 bottom reads + left-d0 bypasses)
+    // members are width-invariant; the per-tree spends (S/J1 top reads,
+    // T2/L2 bottom reads + every left tree's d0 bypass changeovers) grow
+    // with cols: L2 = 4 members + (cols-1) bypasses + (cols-3) reads,
+    // T2 = 4 + (cols-1) + (cols-1), S = 4 + (cols-2), J1 = 3 + (cols-2)
+    const caps = [1, 1, 2, 2, Math.ceil((cols + 2) / 2), 2, 2, Math.ceil((cols + 1) / 2), 2, cols + 1, 2, cols + 2];
+    let off = 0;
+    for (let i = 0; i < NSTATES; i++) {
+      stBanks.push(
+        new MirrorBank({ name: `STPM${i}`, source: mirrorTailOf[i], base: L.STPMIR + off, capacity: caps[i], w, R, minusOf })
+      );
+      off += caps[i];
     }
-    w.push(`${R(LEGINV(c), 'N')}/${R(vm, vArm)}`); // bottom free: tall fork
-    w.push(`${R(vm, vNc)}/${comOf(POSA(c))}`); // flat: step
-    w.push(`${R(vm, vNo)}/${R(LEGINVT(c), 'L')}`); // tall: top-c
-    if (c === 0) {
-      w.push(`${R(LEGINVT(0), 'N')}/${R(SM(3), 'L')}`);
-      w.push(`${R(SM(3), 'K')}/${retTap(1)}`); // the S bound: refuse
-      w.push(`${R(SM(3), 'N')}/${R(LTZ(0), 'H')}`);
-      w.push(`${R(LTZ(0), 'G')}/${retTap(1)}`); // Z: top-1 occupied
-      w.push(`${R(LTZ(0), 'J')}/${R(LTZ(1), 'H')}`);
-      w.push(`${R(LTZ(1), 'G')}/${retTap(1)}`); // Z: top-2 occupied
-      // 3b-4b: the triples' stem targets (T1 top-1, J1 top-2)
-      w.push(`${R(LTZ(1), 'J')}/${R(LTT(0), 'H')}`);
-      w.push(`${R(LTT(0), 'G')}/${retTap(1)}`); // T1: top-1 occupied
-      w.push(`${R(LTT(0), 'J')}/${R(LTJ(0), 'H')}`);
-      w.push(`${R(LTJ(0), 'G')}/${retTap(1)}`); // J1: top-2 occupied
-      // 3b-4c: the overhangs' true bottoms (T2 col 1, L2 col 2)
-      w.push(`${R(LTJ(0), 'J')}/${R(T2B(0), 'H')}`);
-      w.push(`${R(T2B(0), 'G')}/${retTap(1)}`); // T2: bottom-1 occupied
-      w.push(`${R(T2B(0), 'J')}/${R(LTOB(0), 'H')}`);
-      w.push(`${R(LTOB(0), 'G')}/${retTap(1)}`); // L2: bottom-2 occupied
-      w.push(`${R(LTOB(0), 'J')}/${R(vm, vNc)}`); // free: join the step wire
-    } else if (c === 1) {
-      w.push(`${R(LEGINVT(1), 'N')}/${R(LTS(0), 'L')}`);
-      w.push(`${R(LTS(0), 'K')}/${retTap(2)}`); // S: top-0 occupied
-      w.push(`${R(LTS(0), 'N')}/${R(LTZ(1), 'L')}`);
-      w.push(`${R(LTZ(1), 'K')}/${retTap(2)}`); // Z: top-2 occupied
-      w.push(`${R(LTZ(1), 'N')}/${R(LTZ(3), 'L')}`);
-      w.push(`${R(LTZ(3), 'K')}/${retTap(2)}`); // Z: top-3 occupied
-      // 3b-4b: the triples' stem targets (T1 top-2, J1 top-3)
-      w.push(`${R(LTZ(3), 'N')}/${R(LTT(1), 'L')}`);
-      w.push(`${R(LTT(1), 'K')}/${retTap(2)}`); // T1: top-2 occupied
-      w.push(`${R(LTT(1), 'N')}/${R(LTJ(1), 'L')}`);
-      w.push(`${R(LTJ(1), 'K')}/${retTap(2)}`); // J1: top-3 occupied
-      // 3b-4c: the overhangs' true bottoms (T2 col 2, L2 col 3)
-      w.push(`${R(LTJ(1), 'N')}/${R(T2B(1), 'L')}`);
-      w.push(`${R(T2B(1), 'K')}/${retTap(2)}`); // T2: bottom-2 occupied
-      w.push(`${R(T2B(1), 'N')}/${R(LTOB(1), 'L')}`);
-      w.push(`${R(LTOB(1), 'K')}/${retTap(2)}`); // L2: bottom-3 occupied
-      w.push(`${R(LTOB(1), 'N')}/${R(vm, vNc)}`); // free: join the step wire
-    } else {
-      w.push(`${R(LEGINVT(2), 'N')}/${R(LTS(1), 'L')}`);
-      w.push(`${R(LTS(1), 'N')}/${R(LTZ(3), 'H')}`);
-      w.push(`${R(LTZ(3), 'J')}/${R(vm, vNc)}`); // free: join the step wire
-      // position 3 has no return group: the refusals chain jack-to-jack
-      // into the master's coil (the LTS/LTZ NO throws join the chain)
-      w.push(`${R(LEGINV(2), 'K')}/${R(LEGINVT(2), 'K')}`);
-      w.push(`${R(LEGINVT(2), 'K')}/${R(LTS(1), 'K')}`);
-      w.push(`${R(LTS(1), 'K')}/${R(LTZ(3), 'G')}`);
-      w.push(`${R(LTZ(3), 'G')}/${R(POSA(3), 'E')}`);
+    if (off > L.STPMIR_CAP) throw new Error(`step mirrors overflow: ${off} > ${L.STPMIR_CAP}`);
+  }
+  // union rails: a wired-OR of one member contact each (outputs chain
+  // jack to jack, ONE wire enters the coil net — the LEGB trick)
+  let stpUnionN = 0;
+  let stpUGateOff = 0;
+  const mkUnion = (name: string, members: number[]) => {
+    if (stpUnionN >= L.STPUNION_CAP) throw new Error('union rails overflow');
+    const u = L.STPUNION + stpUnionN++;
+    let prev: string | null = null;
+    for (const s of members) {
+      const cs = stBanks[s].request('gate');
+      w.push(`${plusOf(cs.relay)}/${R(cs.relay, cs.arm)}`);
+      if (prev !== null) w.push(`${prev}/${R(cs.relay, cs.no)}`);
+      prev = R(cs.relay, cs.no);
     }
-    if (c !== 2) {
-      w.push(`${R(LEGINV(c), 'K')}/${retTap(c + 1)}`); // bottom occupied
-      w.push(`${R(LEGINVT(c), 'K')}/${retTap(c + 1)}`); // top occupied
+    w.push(`${prev}/${R(u, 'E')}`, `${R(u, 'F')}/${minusOf(u)}`);
+    const gateCap = Math.ceil((cols - 1) / 2) + 1;
+    if (stpUGateOff + gateCap > L.STPUGATE_CAP) throw new Error('union gate mirrors overflow');
+    const bank = new MirrorBank({ name: `${name}G`, source: u, base: L.STPUGATE + stpUGateOff, capacity: gateCap, w, R, minusOf });
+    stpUGateOff += gateCap;
+    return bank;
+  };
+  // state indices by ring order (SHAPES): 0 1x1, 1 2wide, 2 2tall, 3 O,
+  // 4 S, 5 Z, 6 L1, 7 J1, 8 T1, 9 L2, 10 J2, 11 T2
+  const uB0 = mkUnion('B0', [0, 2, 10]); // right bottom d0
+  const uB1 = mkUnion('B1', [1, 3, 4, 5, 11]); // right bottom d1
+  const uB2 = mkUnion('B2', [6, 7, 8, 9]); // right bottom d2
+  const uT0 = mkUnion('T0', [2, 4, 6]); // right top d0
+  const uT1 = mkUnion('T1', [3, 8]); // right top d1
+  const uT2 = mkUnion('T2', [5, 7, 9, 10, 11]); // right top d2
+  const uT0L = mkUnion('T0L', [2, 3, 6, 9, 10, 11]); // left top d0
+  const uT1L = mkUnion('T1L', [5, 8]); // left top d1
+  const uHIB = mkUnion('HIB', [5, 6, 7, 8, 9, 10, 11]); // max == cols-3
+  const uWALLB = mkUnion('WALLB', [1, 3, 4]); // max == cols-2
+  const stpPool = new GatedReadPool({ name: 'STPREAD', source: null, base: L.STPREAD, capacity: L.STPREAD_CAP, w, R, minusOf });
+  // refusal returns per SOURCE column, on matrix groups into the master
+  const retNode = Array.from({ length: cols }, () => takeGroups(4)); // ~15 refusal taps/source peak (width-invariant)
+  for (const g of retNode) for (let i = 1; i < g.length; i++) w.push(`${g[i - 1]}/${g[i]}`);
+  const retUse = Array.from({ length: cols }, () => ({ n: 0 }));
+  const retTap = (p: number) => tap(retNode[p], retUse[p]);
+  for (let s = 0; s < cols; s++) w.push(`${retTap(s)}/${R(POSA(s), 'E')}`);
+  // one tree per (direction, target column)
+  for (const dir of [1, -1] as const) {
+    for (let c = dir > 0 ? 1 : 0; dir > 0 ? c < cols : c < cols - 1; c++) {
+      const src = c - dir;
+      // the sample enters from the direction chain's POSM contact
+      let pending: string[] = [R(POSM(src), dir > 0 ? 'K' : 'G')];
+      const enter = (jack: string) => {
+        for (const p of pending) w.push(`${p}/${jack}`);
+      };
+      // a refusal hop: members up -> return the sample; else continue
+      const refuse = (cs: ContactSet) => {
+        enter(R(cs.relay, cs.arm));
+        w.push(`${R(cs.relay, cs.no)}/${retTap(src)}`);
+        pending = [R(cs.relay, cs.nc)];
+      };
+      // a coil-gated pool read: occupied AND relevant -> return
+      const poolHop = (col: number, gateBank: MirrorBank, top: boolean) => {
+        if (col < 0 || col >= cols) return; // clip: members are refused above
+        const g = gateBank.request('gate');
+        const rd = stpPool.read(top ? legTTap(col) : legTap(col), g);
+        enter(R(rd.relay, rd.set1.arm));
+        w.push(`${R(rd.relay, rd.set1.no)}/${retTap(src)}`);
+        pending = [R(rd.relay, rd.set1.nc)];
+      };
+      // a path-gated read on an EXISTING occupancy changeover (LEGINV /
+      // LEGINVT): gate NO -> the check; gate NC skips it; both continue
+      const gatedHop = (checkRelay: number, set: 1 | 2, gate: ContactSet) => {
+        const [arm, no, nc] = set === 1 ? ['H', 'G', 'J'] : ['L', 'K', 'N'];
+        enter(R(gate.relay, gate.arm));
+        w.push(`${R(gate.relay, gate.no)}/${R(checkRelay, arm)}`);
+        w.push(`${R(checkRelay, no)}/${retTap(src)}`);
+        pending = [R(gate.relay, gate.nc), R(checkRelay, nc)];
+      };
+      // bounds first
+      if (dir > 0 && c === cols - 1) refuse(uWALLB.request('changeover'));
+      if (dir > 0 && c === cols - 2) refuse(uHIB.request('changeover'));
+      if (dir < 0 && c === 0) refuse(stBanks[4].request('changeover')); // S: min 1
+      if (dir > 0) {
+        // right: bottom d0 (path-gated LEGINV set1), d1, d2; top d0
+        // (path-gated LEGINVT set1), d1, d2
+        gatedHop(LEGINV(c), 1, uB0.request('changeover'));
+        poolHop(c + 1, uB1, false);
+        poolHop(c + 2, uB2, false);
+        gatedHop(LEGINVT(c), 1, uT0.request('changeover'));
+        poolHop(c + 1, uT1, true);
+        poolHop(c + 2, uT2, true);
+      } else {
+        // left: bottom d0 = every state but T2 (d1) and L2 (d2) — their
+        // changeovers BYPASS the shared check (NO forward, NC continue)
+        const t2c = stBanks[11].request('changeover');
+        const l2c = stBanks[9].request('changeover');
+        enter(R(t2c.relay, t2c.arm));
+        w.push(`${R(t2c.relay, t2c.nc)}/${R(l2c.relay, l2c.arm)}`);
+        w.push(`${R(t2c.relay, t2c.no)}/${R(l2c.relay, l2c.no)}`); // bypasses tie
+        pending = [R(l2c.relay, l2c.no)];
+        {
+          // the d0 check itself (LEGINV set2), entered from L2's NC
+          const [arm, no, nc] = ['L', 'K', 'N'];
+          w.push(`${R(l2c.relay, l2c.nc)}/${R(LEGINV(c), arm)}`);
+          w.push(`${R(LEGINV(c), no)}/${retTap(src)}`);
+          pending.push(R(LEGINV(c), nc));
+        }
+        poolHop(c + 1, stBanks[11], false); // T2 bottom d1
+        poolHop(c + 2, stBanks[9], false); // L2 bottom d2
+        // top: d-1 (S), d0 (path-gated LEGINVT set2), d1, d2 (J1)
+        poolHop(c - 1, stBanks[4], true); // S top d-1
+        gatedHop(LEGINVT(c), 2, uT0L.request('changeover'));
+        poolHop(c + 1, uT1L, true);
+        poolHop(c + 2, stBanks[7], true); // J1 top d2
+      }
+      // the step: everything survived — coalesce the pending outputs
+      // (jack-to-jack ties) and enter the target master's com with ONE
+      // wire: the com budget is exactly coil + hold + self-loop + this
+      while (pending.length > 1) {
+        const a = pending.pop() as string;
+        w.push(`${a}/${pending[pending.length - 1]}`);
+      }
+      w.push(`${pending[0]}/${comOf(POSA(c))}`);
     }
   }
 
@@ -1869,12 +1859,11 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // can never read occupied at the token row. Branch pairs tie at the
   // LEGB output jacks to fit collideNode's hole budget; a backward walk
   // from the node dead-ends at + or an open contact in every state.
-  // occupied() feeds per column — a CLASS map: 0,1 read LEGINV directly,
-  // 2,3 the LEGINV2 parallel copies (LEGINV(2/3)'s sets are spent). phase
-  // C re-derives which columns need copies at a wider well.
-  const legbFeed = [R(LEGINV(0), 'E'), R(LEGINV(1), 'E'), R(LEGINV2(2), 'E'), R(LEGINV2(3), 'E')];
+  // occupied() feeds per column: the LEGB coils parallel the occupancy
+  // rails' own coil nets at LEGINV(j).E (2-hole budgets fit since the
+  // LEGINV2 copies retired — the coil jack carries rail tap + this)
   for (let j = 0; j < cols; j++) {
-    w.push(`${legbFeed[j]}/${R(LEGB(j), 'E')}`, `${R(LEGB(j), 'F')}/${minusOf(LEGB(j))}`);
+    w.push(`${R(LEGINV(j), 'E')}/${R(LEGB(j), 'E')}`, `${R(LEGB(j), 'F')}/${minusOf(LEGB(j))}`);
     w.push(`${plusOf(PIECET(j))}/${R(PIECET(j), 'L')}`, `${R(PIECET(j), 'K')}/${R(LEGB(j), 'H')}`);
   }
   // branch outputs chain jack-to-jack and enter at COLLIDE's com (its one
@@ -2010,16 +1999,10 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${R(SLJ, 'E')}/${R(SG(0), 'E')}`);
   w.push(`${R(ZM(3), 'E')}/${R(ZM2, 'E')}`, `${R(ZM2, 'E')}/${R(ZG(2), 'E')}`, `${R(ZG(2), 'E')}/${R(ZG(3), 'E')}`);
   w.push(`${R(ZJT, 'E')}/${R(ZG(0), 'E')}`, `${R(ZG(0), 'E')}/${R(ZG(1), 'E')}`);
-  for (const m of [SG(0), SG(1), ZG(0), ZG(1), ZG(2), ZG(3), LTS(0), LTS(1), LTZ(0), LTZ(1), LTZ(2), LTZ(3)])
+  for (const m of [SG(0), SG(1), ZG(0), ZG(1), ZG(2), ZG(3)])
     w.push(`${R(m, 'F')}/${minusOf(m)}`);
   // S-gated reads (coil = rail AND S): columns 0 and 1
-  w.push(`${legTTap(0)}/${R(SG(1), 'H')}`, `${R(SG(1), 'G')}/${R(LTS(0), 'E')}`);
-  w.push(`${legTTap(1)}/${R(SG(1), 'L')}`, `${R(SG(1), 'K')}/${R(LTS(1), 'E')}`);
   // Z-gated reads: column 1, column 2, column 3 (two relays for col 3)
-  w.push(`${legTTap(1)}/${R(ZG(2), 'H')}`, `${R(ZG(2), 'G')}/${R(LTZ(0), 'E')}`);
-  w.push(`${legTTap(2)}/${R(ZG(2), 'L')}`, `${R(ZG(2), 'K')}/${R(LTZ(1), 'E')}`);
-  w.push(`${legTTap(3)}/${R(ZG(3), 'H')}`, `${R(ZG(3), 'G')}/${R(LTZ(2), 'E')}`);
-  w.push(`${R(LTZ(2), 'E')}/${R(LTZ(3), 'E')}`);
 
   // ---------- 3b-3c: UP-transition legality (the last seam) ----------
   // The clock conducts ONLY through a legal transition's branch: the
@@ -2169,14 +2152,9 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${plusOf(SM2)}/${R(SM2, 'H')}`, `${plusOf(L1M(1))}/${R(L1M(1), 'L')}`, `${plusOf(J1M2)}/${R(J1M2, 'H')}`);
   w.push(`${R(SM2, 'G')}/${R(L1M(1), 'K')}`, `${R(L1M(1), 'K')}/${R(J1M2, 'G')}`, `${R(J1M2, 'G')}/${R(SLJ, 'E')}`);
   // J1-only top reads (coil = rail AND J1): cols 2 and 3
-  w.push(`${legTTap(2)}/${R(J1M2, 'L')}`, `${R(J1M2, 'K')}/${R(LTJ(0), 'E')}`);
-  w.push(`${legTTap(3)}/${R(J1M3, 'H')}`, `${R(J1M3, 'G')}/${R(LTJ(1), 'E')}`);
   // T1-only top reads: cols 1 and 2
-  w.push(`${legTTap(1)}/${R(T1M2, 'H')}`, `${R(T1M2, 'G')}/${R(LTT(0), 'E')}`);
-  w.push(`${legTTap(2)}/${R(T1M2, 'L')}`, `${R(T1M2, 'K')}/${R(LTT(1), 'E')}`);
   // the triple-only bottom read of col 3 (TRP's spare set gates it)
-  w.push(`${legTap(3)}/${R(TRP, 'L')}`, `${R(TRP, 'K')}/${R(LTB3, 'E')}`);
-  for (const m of [ZJT, SLJ, ZM2, SM2, J1M2, J1M3, T1M2, LTJ(0), LTJ(1), LTT(0), LTT(1), LTB3])
+  for (const m of [ZJT, SLJ, ZM2, SM2, J1M2, J1M3, T1M2])
     w.push(`${R(m, 'F')}/${minusOf(m)}`);
 
   // ---------- 3b-4c: the overhang trio's coils, rails and fans --------
@@ -2219,11 +2197,6 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${R(POSM5(7), 'E')}/${R(POSM6(3), 'E')}`, `${R(POSM6(3), 'E')}/${R(POSM6(4), 'E')}`, `${R(POSM6(4), 'E')}/${R(POSM6(5), 'E')}`);
   // the overhang reads: LTOT (TT top col3), LTOB (L2 bottoms), T2B (T2
   // bottoms), UTR3 (a parallel coil on the top col3 rail), LEGB3 mirrors
-  w.push(`${legTTap(3)}/${R(TTM(4), 'H')}`, `${R(TTM(4), 'G')}/${R(LTOT, 'E')}`);
-  w.push(`${legTap(2)}/${R(L2M(1), 'L')}`, `${R(L2M(1), 'K')}/${R(LTOB(0), 'E')}`);
-  w.push(`${legTap(3)}/${R(L2M(2), 'H')}`, `${R(L2M(2), 'G')}/${R(LTOB(1), 'E')}`);
-  w.push(`${legTap(1)}/${R(T2M(1), 'L')}`, `${R(T2M(1), 'K')}/${R(T2B(0), 'E')}`);
-  w.push(`${legTap(2)}/${R(T2M(2), 'H')}`, `${R(T2M(2), 'G')}/${R(T2B(1), 'E')}`);
   w.push(`${R(UTR(6), 'E')}/${R(UTR3, 'E')}`);
   w.push(`${R(LEGB2(0), 'E')}/${R(LEGB3(0), 'E')}`);
   w.push(`${R(LEGB2(1), 'E')}/${R(LEGB3(1), 'E')}`);
@@ -2247,7 +2220,7 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${R(UTR2(2), 'N')}/${R(UTR3, 'J')}`, `${R(UTR3, 'J')}/${R(LEGB(0), 'N')}`);
   w.push(`${R(LEGB(0), 'N')}/${R(LEGB2(0), 'N')}`, `${R(LEGB2(0), 'N')}/${R(LEGB3(0), 'J')}`);
   w.push(`${R(LEGB3(0), 'J')}/${R(LEGB3(1), 'J')}`, `${R(LEGB3(1), 'J')}/${R(LEGB3(2), 'J')}`);
-  for (const m of [MMIR3(9), MMIR3(10), MMIR3(11), TT, TTM(0), TTM(1), TTM(2), TTM(3), TTM(4), BCUT, BCUTM, L2M(0), L2M(1), L2M(2), J2M, T2M(0), T2M(1), T2M(2), LTOT, LTOB(0), LTOB(1), T2B(0), T2B(1), UTR3, LEGB3(0), LEGB3(1), LEGB3(2), POSM6(0), POSM6(1), POSM6(2), POSM6(3), POSM6(4), POSM6(5)])
+  for (const m of [MMIR3(9), MMIR3(10), MMIR3(11), TT, TTM(0), TTM(1), TTM(2), TTM(3), TTM(4), BCUT, BCUTM, L2M(0), L2M(1), L2M(2), J2M, T2M(0), T2M(1), T2M(2), UTR3, LEGB3(0), LEGB3(1), LEGB3(2), POSM6(0), POSM6(1), POSM6(2), POSM6(3), POSM6(4), POSM6(5)])
     w.push(`${R(m, 'F')}/${minusOf(m)}`);
 
   // ---------- 3b-5: the self-tick oscillator (see the constants) -------

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -17,6 +17,8 @@
  * list is the compiled output.
  */
 
+import { MirrorBank } from './contact-alloc';
+
 // ---- relay allocation: relay n lives at machine floor(n/6), section n%6+1
 export const R = (n: number, jack: string) => `m${Math.floor(n / 6)}.${(n % 6) + 1}${jack}`;
 export const comOf = (n: number) => `m${Math.floor(n / 6)}.${(n % 6) + 1}com`;
@@ -1619,9 +1621,14 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${legTTap(3)}/${R(SG(0), 'L')}`, `${R(SG(0), 'N')}/${R(LEGINVT2(3), 'E')}`, `${R(LEGINVT2(3), 'F')}/${minusOf(LEGINVT2(3))}`);
   // vmode mirrors for the tall forks (VMODE's own spare set can't serve
   // six tap trees); coils daisy-chained through the coil jacks
-  w.push(`${R(VMODE, 'E')}/${R(VMODEM(0), 'E')}`);
-  for (let p = 1; p < cols; p++) w.push(`${R(VMODEM(p - 1), 'E')}/${R(VMODEM(p), 'E')}`);
-  for (let p = 0; p < cols; p++) w.push(`${R(VMODEM(p), 'F')}/${minusOf(VMODEM(p))}`);
+  // ...as the first allocator-managed bank (wider-well emitter 0 pilot):
+  // the bank mints the same chain lazily; requests below arrive in the
+  // hand-laid order, so the set map is unchanged (wire-multiset gate).
+  // NOTE the chain tail stays a splice point: the ring-state union
+  // enters at VMODEM(cols-1).E's free hole (the 3b-4a/4c splices).
+  const vmBank = new MirrorBank({
+    name: 'VMODEM', source: VMODE, base: VMODEM(0), capacity: cols, w, R, minusOf,
+  });
 
   // the gated D-taps: every stage is a CHANGEOVER (blocked returns the
   // sample to the current master — see the ring notes) and every OPTIONAL
@@ -1647,7 +1654,8 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   w.push(`${retTap(1)}/${R(POSA(1), 'E')}`);
   w.push(`${retTap(2)}/${R(POSA(2), 'E')}`);
   for (const c of [1, 2] as const) {
-    const vm = VMODEM(c - 1);
+    const tf = vmBank.request('changeover'); // the tall fork
+    const tw = vmBank.request('changeover'); // the tall-wide fork
     const [wArm, wNc, wNo] = c === 1 ? ['H', 'J', 'G'] : ['L', 'N', 'K'];
     if (c === 1) {
       // 3b-4c: the OVR bypass — LEGINV(c) false-refuses L2/T2 (their
@@ -1656,13 +1664,13 @@ export function tetrisCircuit(rows = 8, cols = 4): {
       // bottom columns read as gated hops further down
       w.push(`${R(POSM(0), 'K')}/${R(BCUTM, 'H')}`);
       w.push(`${R(BCUTM, 'J')}/${R(LEGINV(1), 'H')}`);
-      w.push(`${R(BCUTM, 'G')}/${R(vm, 'H')}`); // overhang: skip to the fork
+      w.push(`${R(BCUTM, 'G')}/${R(tf.relay, tf.arm)}`); // overhang: skip to the fork
     } else {
       w.push(`${R(POSM(c - 1), 'K')}/${R(LEGINV(c), 'H')}`); // the tap in
     }
     w.push(`${R(LEGINV(c), 'G')}/${retTap(c - 1)}`); // bottom-c occupied
-    w.push(`${R(LEGINV(c), 'J')}/${R(vm, 'H')}`); // free: the tall fork
-    w.push(`${R(vm, 'G')}/${R(LEGINVT(c), 'H')}`); // tall: check top-c
+    w.push(`${R(LEGINV(c), 'J')}/${R(tf.relay, tf.arm)}`); // free: the tall fork
+    w.push(`${R(tf.relay, tf.no)}/${R(LEGINVT(c), 'H')}`); // tall: check top-c
     w.push(`${R(LEGINVT(c), 'G')}/${retTap(c - 1)}`); // top-c occupied
     // 3b-3b: S's extra top column (c-1) rides IN SERIES — under any other
     // mode the LTS coil is dead and its NC passes through. For c=2 the Z
@@ -1684,7 +1692,7 @@ export function tetrisCircuit(rows = 8, cols = 4): {
       w.push(`${R(LTOT, 'G')}/${retTap(0)}`); // TT: top-3 occupied
       w.push(`${R(LTOT, 'J')}/${R(LTOB(1), 'H')}`);
       w.push(`${R(LTOB(1), 'G')}/${retTap(0)}`); // L2: bottom-3 occupied
-      w.push(`${R(LTOB(1), 'J')}/${R(vm, 'J')}`); // free: join X
+      w.push(`${R(LTOB(1), 'J')}/${R(tf.relay, tf.nc)}`); // free: join X
     } else {
       w.push(`${R(LEGINVT(2), 'J')}/${R(LTS(1), 'H')}`);
       w.push(`${R(LTS(1), 'G')}/${retTap(1)}`); // S: top-1 occupied
@@ -1696,48 +1704,49 @@ export function tetrisCircuit(rows = 8, cols = 4): {
       w.push(`${R(TRPM(1), 'K')}/${retTap(1)}`);
       w.push(`${R(TRPM(1), 'N')}/${R(TTM(4), 'L')}`);
       w.push(`${R(TTM(4), 'K')}/${retTap(1)}`);
-      w.push(`${R(TTM(4), 'N')}/${R(vm, 'J')}`); // free: join X
+      w.push(`${R(TTM(4), 'N')}/${R(tf.relay, tf.nc)}`); // free: join X
     }
-    w.push(`${R(vm, 'J')}/${R(WIDM3, wArm)}`); // X: the wide fork
+    w.push(`${R(tf.relay, tf.nc)}/${R(WIDM3, wArm)}`); // X: the wide fork
     w.push(`${R(WIDM3, wNc)}/${comOf(POSA(c))}`); // narrow: step
     w.push(`${R(WIDM3, wNo)}/${R(LEGINV2(c + 1), 'H')}`); // wide: bottom-c+1
     w.push(`${R(LEGINV2(c + 1), 'G')}/${retTap(c - 1)}`); // occupied
-    w.push(`${R(LEGINV2(c + 1), 'J')}/${R(vm, 'L')}`); // free: tall fork #2
-    w.push(`${R(vm, 'N')}/${R(WIDM3, wNc)}`); // flat-wide: join the step wire
-    w.push(`${R(vm, 'K')}/${R(LEGINVT2(c + 1), 'H')}`); // tall-wide: top-c+1
+    w.push(`${R(LEGINV2(c + 1), 'J')}/${R(tw.relay, tw.arm)}`); // free: tall fork #2
+    w.push(`${R(tw.relay, tw.nc)}/${R(WIDM3, wNc)}`); // flat-wide: join the step wire
+    w.push(`${R(tw.relay, tw.no)}/${R(LEGINVT2(c + 1), 'H')}`); // tall-wide: top-c+1
     w.push(`${R(LEGINVT2(c + 1), 'G')}/${retTap(c - 1)}`); // occupied
     // 3b-3b: Z's extra top column (c+2) — only c=1 has one on the board
     // (c=2's Z was already returned by the bound at point 1)
     if (c === 1) {
       w.push(`${R(LEGINVT2(2), 'J')}/${R(LTZ(2), 'H')}`);
       w.push(`${R(LTZ(2), 'G')}/${retTap(0)}`); // Z: top-3 occupied
-      w.push(`${R(LTZ(2), 'J')}/${R(vm, 'N')}`); // free: join
+      w.push(`${R(LTZ(2), 'J')}/${R(tw.relay, tw.nc)}`); // free: join
     } else {
-      w.push(`${R(LEGINVT2(3), 'J')}/${R(vm, 'N')}`); // free: join
+      w.push(`${R(LEGINVT2(3), 'J')}/${R(tw.relay, tw.nc)}`); // free: join
     }
   }
+  const wallTf = vmBank.request('changeover'); // VMODEM(2).set1, hand order
   w.push(`${R(POSM(2), 'K')}/${R(LEGINV(3), 'H')}`);
   w.push(`${R(LEGINV(3), 'G')}/${retTap(2)}`); // bottom-3 occupied
-  w.push(`${R(LEGINV(3), 'J')}/${R(VMODEM(2), 'H')}`); // free: the tall fork
-  w.push(`${R(VMODEM(2), 'G')}/${R(LEGINVT(3), 'H')}`); // tall: top-3
+  w.push(`${R(LEGINV(3), 'J')}/${R(wallTf.relay, wallTf.arm)}`); // free: the tall fork
+  w.push(`${R(wallTf.relay, wallTf.no)}/${R(LEGINVT(3), 'H')}`); // tall: top-3
   w.push(`${R(LEGINVT(3), 'G')}/${retTap(2)}`); // occupied
-  w.push(`${R(LEGINVT(3), 'J')}/${R(VMODEM(2), 'J')}`); // free: join
-  w.push(`${R(VMODEM(2), 'J')}/${R(WIDM4, 'H')}`); // the wall gate
+  w.push(`${R(LEGINVT(3), 'J')}/${R(wallTf.relay, wallTf.nc)}`); // free: join
+  w.push(`${R(wallTf.relay, wallTf.nc)}/${R(WIDM4, 'H')}`); // the wall gate
   w.push(`${R(WIDM4, 'J')}/${comOf(POSA(3))}`); // narrow: step
   w.push(`${R(WIDM4, 'G')}/${retTap(2)}`); // wide: the wall, return
-  // left taps: the tall fork sets — VMODEM(2).set2 serves left-into-0,
-  // VMODEM(3)'s two sets serve left-into-1 and left-into-2
-  const leftFork: Array<[number, string, string, string]> = [
-    [VMODEM(2), 'L', 'N', 'K'], // into 0
-    [VMODEM(3), 'H', 'J', 'G'], // into 1
-    [VMODEM(3), 'L', 'N', 'K'], // into 2
+  // left taps: the tall fork sets — requested in the hand-laid order
+  // (VMODEM(2).set2 into 0, then VMODEM(3)'s two sets into 1 and 2)
+  const leftFork = [
+    vmBank.request('changeover'), // into 0
+    vmBank.request('changeover'), // into 1
+    vmBank.request('changeover'), // into 2
   ];
   // 3b-3b: each left tree's tall path gains its mode hops in series after
   // the (NOT-Z-gated) symmetric check: the S bound (left into 0 is out of
   // S's fit range) or S's extra column c-1, then Z's true target columns
   // c+1 / c+2 (dead coils pass through; left into 2 clips c+2 = 4).
   for (const c of [0, 1, 2] as const) {
-    const [vm, vArm, vNc, vNo] = leftFork[c];
+    const { relay: vm, arm: vArm, nc: vNc, no: vNo } = leftFork[c];
     if (c === 0) {
       // 3b-4c: the OVR bypass (see the right tree) — L2/T2 skip the
       // false bottom check; their true columns read further down

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -257,6 +257,22 @@ export const T2B = (k: number) => 490 + k; // T2-gated bottom reads: k=0 col1, k
 export const UTR3 = 492; // one more top-col3 read (the T1->L2 transition)
 export const LEGB3 = (k: number) => 493 + k; // more bottom reads: k=0 col1, k=1 col2, k=2 col0
 export const POSM6 = (k: number) => 496 + k; // pos mirrors: k=0..2 pos0, k=3..5 pos1 (496..501)
+// 3b-5 — THE MACHINE TICKS ITSELF: a two-relay slow-release oscillator
+// on real capacitors. TOSC's coil parallels a paralleled cap bank and is
+// fed through TDRV's NC; TDRV is fed through TOSC's NO; TDRV's second
+// set bridges + onto the tick net exactly as the tick slide's closure
+// does (compatibility-OR — the slide still works). The cycle under
+// stepTime: the supply recharges the bank in one backward-Euler step,
+// TOSC+TDRV latch up (tick HIGH) while the bank drains through the coil,
+// dropout breaks the pair and the transition solve BUZZES (the armature
+// flap chatter-pins both down — a real relay oscillator buzzes; the game
+// machinery is chatter-tolerant, device-verified class) leaving one
+// clean tick-LOW step, then the recharge refires. AUTO = the slide on
+// TOSC's own section: the operator chooses self-play. Period: a few
+// hundred ms with four paralleled sections at 100ms steps (measured in
+// the oscillator test; more sections or larger steps slow it further).
+export const TOSC = 502; // the timing relay (coil || cap bank)
+export const TDRV = 503; // the driver: follows TOSC, its set2 drives the tick net
 export const MMIR = (i: number) => 393 + i; // master mirrors: gate the into-state-i branch (393..398)
 export const POSM4 = (k: number) => 399 + k; // pos mirrors for the branches: k=0 pos0, k=1,2 pos1, k=3,4 pos2, k=5 pos3 (399..404)
 // (POSM4(5) exists because NOTHING on POSM(3) was borrowable: its L arm
@@ -359,6 +375,7 @@ export interface TetrisLayout {
   L2M: (k: number) => number; J2M: number; T2M: (k: number) => number;
   LTOT: number; LTOB: (k: number) => number; T2B: (k: number) => number;
   UTR3: number; LEGB3: (k: number) => number; POSM6: (k: number) => number;
+  TOSC: number; TDRV: number;
   btnMachine: number; // the dedicated (relay-free) button/slide machine
   machines: number;
   relays: number; // wired coils (the junction gap is com-only)
@@ -428,6 +445,7 @@ export function tetrisLayout(rows: number): TetrisLayout {
   const g4bBase = take(12); // 3b-4b: ZJT, SLJ, ZM2, SM2, J1M2/3, T1M2, LTJ x2, LTT x2, LTB3
   const shr3Base = take(9); // 3b-4c: states 9..11 (L2, J2, T2)
   const g4cBase = take(33); // MMIR3 x3, TT+TTM x6, BCUT x2, L2M x3, J2M, T2M x3, LTOT, LTOB x2, T2B x2, UTR3, LEGB3 x3, POSM6 x6
+  const oscBase = take(2); // 3b-5: TOSC, TDRV (the self-tick oscillator)
   return {
     rows,
     A0: aBase, A0m: aBase + 1, A1: aBase + 2, A2: aBase + 3,
@@ -502,6 +520,7 @@ export function tetrisLayout(rows: number): TetrisLayout {
     L2M: k => g4cBase + 11 + k, J2M: g4cBase + 14, T2M: k => g4cBase + 15 + k,
     LTOT: g4cBase + 18, LTOB: k => g4cBase + 19 + k, T2B: k => g4cBase + 21 + k,
     UTR3: g4cBase + 23, LEGB3: k => g4cBase + 24 + k, POSM6: k => g4cBase + 27 + k,
+    TOSC: oscBase, TDRV: oscBase + 1,
     btnMachine: Math.ceil(n / 6),
     machines: Math.ceil(n / 6) + 1,
     relays: n - (rows - 3),
@@ -599,6 +618,7 @@ export function tetrisLayout(rows: number): TetrisLayout {
   claim('overhang reads', LTOT, LTOB(0), LTOB(1), T2B(0), T2B(1), UTR3);
   claim('LEGB3', LEGB3(0), LEGB3(1), LEGB3(2));
   for (let k = 0; k < 6; k++) claim('POSM6', POSM6(k));
+  claim('TOSC/TDRV', TOSC, TDRV);
 
   // the parameterized layout must reproduce the hand-laid map exactly at
   // the default geometry — every scalar, every function over its domain,
@@ -682,6 +702,7 @@ export function tetrisLayout(rows: number): TetrisLayout {
   eq('LTOT', L.LTOT, LTOT); eq('LTOB', L.LTOB(0), LTOB(0)); eq('LTOB', L.LTOB(1), LTOB(1));
   eq('T2B', L.T2B(0), T2B(0)); eq('T2B', L.T2B(1), T2B(1)); eq('UTR3', L.UTR3, UTR3);
   for (let k = 0; k < 6; k++) eq('POSM6', L.POSM6(k), POSM6(k));
+  eq('TOSC', L.TOSC, TOSC); eq('TDRV', L.TDRV, TDRV);
   eq('machines', L.machines, MACHINES);
   eq('btnMachine', L.btnMachine, LEFTBTN.machine);
   eq('btnMachine2', L.btnMachine, RIGHTBTN.machine);
@@ -716,6 +737,7 @@ export function tetrisCircuit(rows = 8): {
     ZJT, SLJ, ZM2, SM2, J1M2, J1M3, T1M2, LTJ, LTT, LTB3,
     SHR3, MMIR3, TT, TTM, BCUT, BCUTM, L2M, J2M, T2M,
     LTOT, LTOB, T2B, UTR3, LEGB3, POSM6,
+    TOSC, TDRV,
   } = L;
   // buttons/slides live on the layout's dedicated relay-free machine:
   // every anchor that shared a machine with relays eventually collided
@@ -2250,6 +2272,20 @@ export function tetrisCircuit(rows = 8): {
   for (const m of [MMIR3(9), MMIR3(10), MMIR3(11), TT, TTM(0), TTM(1), TTM(2), TTM(3), TTM(4), BCUT, BCUTM, L2M(0), L2M(1), L2M(2), J2M, T2M(0), T2M(1), T2M(2), LTOT, LTOB(0), LTOB(1), T2B(0), T2B(1), UTR3, LEGB3(0), LEGB3(1), LEGB3(2), POSM6(0), POSM6(1), POSM6(2), POSM6(3), POSM6(4), POSM6(5)])
     w.push(`${R(m, 'F')}/${minusOf(m)}`);
 
+  // ---------- 3b-5: the self-tick oscillator (see the constants) -------
+  const om = Math.floor(TOSC / 6);
+  const os = (TOSC % 6) + 1;
+  w.push(`m${om}.${os}+/m${om}.${os}S`, `m${om}.${os}T/${R(TDRV, 'H')}`); // AUTO gates the feed
+  w.push(`${R(TDRV, 'J')}/${R(TOSC, 'E')}`, `${R(TOSC, 'F')}/${minusOf(TOSC)}`);
+  w.push(`${R(TOSC, 'E')}/m${om}.${os}cap`); // the coil parallels the bank
+  const capSecs = [os, ...[1, 2, 3, 4, 5, 6].filter(s => s !== os).slice(0, 3)];
+  for (let i = 1; i < capSecs.length; i++)
+    w.push(`m${om}.${capSecs[i - 1]}cap/m${om}.${capSecs[i]}cap`);
+  w.push(`${plusOf(TOSC)}/${R(TOSC, 'H')}`, `${R(TOSC, 'G')}/${R(TDRV, 'E')}`, `${R(TDRV, 'F')}/${minusOf(TDRV)}`);
+  // the tick bridge: TDRV's set2 puts + on the tick net exactly as the
+  // slide's S-T closure does (both dead-end open when inactive)
+  w.push(`${plusOf(TDRV)}/${R(TDRV, 'L')}`, `${R(TDRV, 'K')}/${R(LKS, 'H')}`);
+
   return { wires: w, rails: dataRails, layout: L, btnMachine };
 }
 
@@ -2268,6 +2304,11 @@ export const TETRIS_IO = {
     const s = i < 6 ? SHR(i, 2) : i < 9 ? SHR2(i, 2) : SHR3(i, 2);
     return { machine: Math.floor(s / 6), index: s % 6 };
   },
+  // AUTO: the oscillator's own section slide — right = the machine ticks
+  // itself under stepTime (3b-5); the tick slide stays live in parallel
+  auto: { slide: (TOSC % 6) + 1, machine: Math.floor(TOSC / 6) },
+  // TDRV up = the oscillator is holding the tick line high
+  oscRelay: { machine: Math.floor(TDRV / 6), index: TDRV % 6 },
   // LKS up = the machine owes itself bookkeeping ticks (phase 2 / reset)
   lockedRelay: { machine: Math.floor(LKS / 6), index: LKS % 6 },
   // LANE up = a collapse is in progress: ticks walk the stack down

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -1809,8 +1809,12 @@ export function tetrisCircuit(rows = 8, cols = 4): {
   // so the tap banks mirror THROUGH a retired fork contact instead of
   // parallel-coiling: + -> WIDM4.set1 (freed by the tree emitter) -> the
   // bank's coil chain; same signal, one freed contact set each
+  // WIDM4 set1 belongs to the T1 union's legacy triple (VMODEM(1).G
+  // feeds the H arm) — feeding + into the same arm would delete the
+  // VMODE term (found the hard way: a flat wide pair read the top).
+  // set2 is genuinely free.
   const widmBank = new MirrorBank({ name: 'FANWIDM', source: null, base: L.FANMIR, capacity: Math.ceil(cols / 2), w, R, minusOf });
-  w.push(`${plusOf(WIDM4)}/${R(WIDM4, 'H')}`, `${R(WIDM4, 'G')}/${R(L.FANMIR, 'E')}`);
+  w.push(`${plusOf(WIDM4)}/${R(WIDM4, 'L')}`, `${R(WIDM4, 'K')}/${R(L.FANMIR, 'E')}`);
   const wid3Bank = new MirrorBank({ name: 'FANWID3', source: null, base: L.FANMIR + Math.ceil(cols / 2), capacity: Math.ceil(cols / 2), w, R, minusOf });
   w.push(`${plusOf(WID3M)}/${R(WID3M, 'H')}`, `${R(WID3M, 'G')}/${R(L.FANMIR + Math.ceil(cols / 2), 'E')}`);
   for (let j = 1; j < cols; j++) {

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -233,6 +233,17 @@ export const shapeRange = (s: (typeof SHAPES)[number], cols: number) => ({
   min: Math.max(0, -s.bOff, s.tW > 0 ? -s.tOff : 0),
   max: Math.min(cols - s.bOff - s.bW, s.tW > 0 ? cols - s.tOff - s.tW : cols),
 });
+// the cells a step must check, as OFFSETS from the target position q:
+// stepping RIGHT enters bottom q+bOff+bW-1 (its rightmost bottom cell)
+// and top q+tOff+tW-1; LEFT enters q+bOff and q+tOff. every other
+// footprint cell was already covered (or is the piece's own, which can
+// never coexist with stored content). the step-tree emitter instantiates
+// these per interior column; verified against three hand-laid trees
+// (_notes/wider-well.md, the check tables).
+export const stepEntering = (s: (typeof SHAPES)[number], dir: 1 | -1) => ({
+  b: dir > 0 ? s.bOff + s.bW - 1 : s.bOff,
+  t: s.tW > 0 ? (dir > 0 ? s.tOff + s.tW - 1 : s.tOff) : null,
+});
 export const SHR2 = L8.SHR2; // states 6..8: clk, master, slave (415..423)
 export const MMIR2 = L8.MMIR2; // into-6..8 transition gates (424..426)
 // POSM5 set map (7 pos0 + 7 pos1 uses): k=0 B-fan PIECE(2) + T-fan L1;

--- a/src/circuits/multivac-mini-tetris.ts
+++ b/src/circuits/multivac-mini-tetris.ts
@@ -25,41 +25,47 @@ export const comOf = (n: number) => `m${Math.floor(n / 6)}.${(n % 6) + 1}com`;
 export const plusOf = (n: number) => `m${Math.floor(n / 6)}.${(n % 6) + 1}+`;
 export const minusOf = (n: number) => `m${Math.floor(n / 6)}.${(n % 6) + 1}-`;
 
-export const A0 = 0, A0m = 1, A1 = 2, A2 = 3; // decoder address relays
-export const W = (r: number, k: number) => 4 + 4 * r + k; // write groups, k = 0..3
-export const CELL = (r: number, j: number) => 36 + 4 * r + j; // field cells
-export const RING = (i: number, part: number) => 68 + 3 * i + part; // clk, master, slave
-export const MIRA = (r: number) => 92 + 2 * r; // slave mirror A (W triggers)
-export const MIRB = (r: number) => 93 + 2 * r; // slave mirror B (collision)
-export const RESETM = (x: number) => 108 + x; // 4 reset mirrors, 2 stages each
-export const COLLIDE = 112, COLLIDEM = 113, LKM = 114, RSTM = 115;
-export const SPAWN = 116, SPAWNCLR = 117, CLEARP = 118; // CLEARP: line-clear pending
-export const LINE = (j: number) => 119 + j;
-export const PIECE = (j: number) => 123 + j;
-export const LKS = 127, TICKM = 128; // LOCKED slave + tick-phase mirror
-export const COLLIDEM2 = 129; // isolates the collision node from COLLIDE's com
-export const READGATE = 130; // depth-1 press relay: powers the depth-2 rails
-export const MIRB2 = (r: number) => 131 + r; // second collision mirror per row
-export const PRESSCUT = (x: number) => 139 + x; // 4 relays: drop the collision mirrors during a press
-export const RAILGATE2 = 143; // second-hop rail power, aligns rail life with the W group
-export const RSTM2 = 144; // clears the CLEARP latch during the reset tick
-export const CPSET = 145; // isolates CLEARP's set path from the LINE chain
+// the DEFAULT-GEOMETRY map: every constant below derives from the
+// layout allocator at (8 rows, 4 cols) — tetrisLayout is the primary
+// source now (wider-well phase C shifts bank sizes; literals would
+// break). the inline comments document each bank; jack ranges in
+// them describe TODAY'S map and move with the allocator.
+const L8 = tetrisLayout(8);
+export const A0 = L8.A0, A0m = L8.A0m, A1 = L8.A1, A2 = L8.A2; // decoder address relays
+export const W = L8.W; // write groups, k = 0..3
+export const CELL = L8.CELL; // field cells
+export const RING = L8.RING; // clk, master, slave
+export const MIRA = L8.MIRA; // slave mirror A (W triggers)
+export const MIRB = L8.MIRB; // slave mirror B (collision)
+export const RESETM = L8.RESETM; // 4 reset mirrors, 2 stages each
+export const COLLIDE = L8.COLLIDE, COLLIDEM = L8.COLLIDEM, LKM = L8.LKM, RSTM = L8.RSTM;
+export const SPAWN = L8.SPAWN, SPAWNCLR = L8.SPAWNCLR, CLEARP = L8.CLEARP; // CLEARP: line-clear pending
+export const LINE = L8.LINE;
+export const PIECE = L8.PIECE;
+export const LKS = L8.LKS, TICKM = L8.TICKM; // LOCKED slave + tick-phase mirror
+export const COLLIDEM2 = L8.COLLIDEM2; // isolates the collision node from COLLIDE's com
+export const READGATE = L8.READGATE; // depth-1 press relay: powers the depth-2 rails
+export const MIRB2 = L8.MIRB2; // second collision mirror per row
+export const PRESSCUT = L8.PRESSCUT; // 4 relays: drop the collision mirrors during a press
+export const RAILGATE2 = L8.RAILGATE2; // second-hop rail power, aligns rail life with the W group
+export const RSTM2 = L8.RSTM2; // clears the CLEARP latch during the reset tick
+export const CPSET = L8.CPSET; // isolates CLEARP's set path from the LINE chain
 // ---- vertical pieces ("phase-2 top write", roadmap rung 9b) ----
 // a vertical piece = the column mask, two cells tall. The bottom cell IS the
 // token (collision unchanged: the bottom leads). The lock press writes the
 // bottom row through the existing path, untouched; a P2 master/slave pair
 // then turns the NEXT tick into phase 2 — a second, private write of row
 // r-1 through the TOPW mirrors — and the reset moves to the tick after.
-export const VMODE = 146; // piece-shape mode relay (slide-driven)
-export const TOPW = (r: number) => 146 + r; // r=1..7: slave-r mirrors, route the phase-2 triggers to row r-1
-export const P2M = 154; // phase-2 master: latched by a vertical lock press
-export const P2S = 155; // phase-2 slave: the resetrail branch contact (two-phase, like LKS)
-export const P2CLR = 156; // breaks P2M's latch during phase 2 (like RSTM for LKM)
-export const P2GATE = 157; // phase-2 READGATE: powers the two trigger rails
-export const P2COL = 158; // phase-2 RAILGATE2: powers the column feed
-export const TICKM2 = 159; // second tick mirror: clocks P2M -> P2S (TICKM's contacts are spoken for)
-export const P2CUT = (x: number) => 160 + x; // 4 relays: drop the collision mirrors during phase 2
-export const LINEDLY = 164; // delays the LINE chain's feed past the collision-sense cut
+export const VMODE = L8.VMODE; // piece-shape mode relay (slide-driven)
+export const TOPW = L8.TOPW; // r=1..7: slave-r mirrors, route the phase-2 triggers to row r-1
+export const P2M = L8.P2M; // phase-2 master: latched by a vertical lock press
+export const P2S = L8.P2S; // phase-2 slave: the resetrail branch contact (two-phase, like LKS)
+export const P2CLR = L8.P2CLR; // breaks P2M's latch during phase 2 (like RSTM for LKM)
+export const P2GATE = L8.P2GATE; // phase-2 READGATE: powers the two trigger rails
+export const P2COL = L8.P2COL; // phase-2 RAILGATE2: powers the column feed
+export const TICKM2 = L8.TICKM2; // second tick mirror: clocks P2M -> P2S (TICKM's contacts are spoken for)
+export const P2CUT = L8.P2CUT; // 4 relays: drop the collision mirrors during phase 2
+export const LINEDLY = L8.LINEDLY; // delays the LINE chain's feed past the collision-sense cut
 // ---- row collapse ("the elevator", roadmap rung 10) ----
 // after a line clear at row r the hole walks UP: THREE ticks per row —
 // alpha fires the source and hole rows' gates only (the source's content
@@ -76,31 +82,31 @@ export const LINEDLY = 164; // delays the LINE chain's feed past the collision-s
 // clock) and drains by walking off stage 1. Full design + rejected
 // alternatives + the observed-but-unexplained alpha-release anomaly:
 // _notes/collapse-design.md
-export const ELEVC = (t: number) => 162 + 3 * t; // stage clocks (165..183)
-export const ELEVA = (t: number) => 163 + 3 * t; // stage masters (166..184)
-export const ELEVSL = (t: number) => 164 + 3 * t; // stage slaves (167..185)
-export const SEEDM = (t: number) => 185 + t; // ring-slave mirrors: seed the chain at the token row (186..192)
-export const CLEARPM = 193; // CLEARP mirror: scopes the seed to clearing locks
-export const LANE = 194; // collapse tick-lane slave (branches between LKS and COLLIDE)
-export const TICKM3 = 195; // third tick mirror: clocks LANE and the phase toggle
-export const TGM = 196, TGS = 197; // phase bit 0 (master/slave)
-export const TG2M = 222, TG2S = 223; // phase bit 1: the collapse is THREE
+export const ELEVC = L8.ELEVC; // stage clocks (165..183)
+export const ELEVA = L8.ELEVA; // stage masters (166..184)
+export const ELEVSL = L8.ELEVSL; // stage slaves (167..185)
+export const SEEDM = L8.SEEDM; // ring-slave mirrors: seed the chain at the token row (186..192)
+export const CLEARPM = L8.CLEARPM; // CLEARP mirror: scopes the seed to clearing locks
+export const LANE = L8.LANE; // collapse tick-lane slave (branches between LKS and COLLIDE)
+export const TICKM3 = L8.TICKM3; // third tick mirror: clocks LANE and the phase toggle
+export const TGM = L8.TGM, TGS = L8.TGS; // phase bit 0 (master/slave)
+export const TG2M = L8.TG2M, TG2S = L8.TG2S; // phase bit 1: the collapse is THREE
 // ticks per stage — alpha (gates-only move), beta (breakers-only clear),
 // gamma (chain step with every rail dark). Stepping with a hot rail fired
 // the freshly hot stage's routing mid-tick and killed the next row before
 // its copy (the trace caught it); gamma isolates the step. Cycle:
 // alpha arms TGM -> beta (TGS); beta arms TG2M -> gamma (TG2S); gamma arms
 // nothing -> alpha. Decodes ride the toggles' own contacts off cgbRail.
-export const ELEVW1 = (t: number) => 196 + 2 * t; // trigger-routing mirrors (198..210 even)
-export const ELEVW2 = (t: number) => 197 + 2 * t; // (199..211 odd)
-export const CGA = 212, CGB = 213; // collapse rail feeds (alpha rail / both-phase rail)
-export const CGB2 = 214; // second-hop breaker rail: aligns the source hold-break with the gate wave
-export const CUTC1 = 215, CUTC2 = 216; // cut the piece arms off colFan during a collapse
-export const CUTC3 = 224, CUTC4 = 225; // and the piece taps off collideNode: with 2+ mask
+export const ELEVW1 = L8.ELEVW1; // trigger-routing mirrors (198..210 even)
+export const ELEVW2 = L8.ELEVW2; // (199..211 odd)
+export const CGA = L8.CGA, CGB = L8.CGB; // collapse rail feeds (alpha rail / both-phase rail)
+export const CGB2 = L8.CGB2; // second-hop breaker rail: aligns the source hold-break with the gate wave
+export const CUTC1 = L8.CUTC1, CUTC2 = L8.CUTC2; // cut the piece arms off colFan during a collapse
+export const CUTC3 = L8.CUTC3, CUTC4 = L8.CUTC4; // and the piece taps off collideNode: with 2+ mask
 // columns the collision fan is a SECOND rail-to-rail bridge (rail -> K ->
 // collideNode -> K' -> rail'), and the phase decode's gap-held gates would
 // latch a bridged bit (caught by the instrumented random run at tick 31)
-export const JUNC = (k: number) => 216 + k; // spare-section 4-hole coms as junction boxes
+export const JUNC = L8.JUNC; // spare-section 4-hole coms as junction boxes
 // (JUNC(0) shares m36.1 with CUTC2 — a section's com jack is electrically
 // separate from its relay, so the junction coexists with the coil)
 // ---- the piece register, increment 1 (roadmap piece rung) ----
@@ -113,44 +119,44 @@ export const JUNC = (k: number) => 216 + k; // spare-section 4-hole coms as junc
 // AND the seeding story. The PIECE column relays re-feed from the register:
 // slave j's tap, or WIDM AND slave j-1 (the wide edge). Width itself is the
 // WID slide; legality gating (lateral collision) is the next increment.
-export const POSA = (j: number) => 226 + j; // step masters (226..229)
-export const POSS = (j: number) => 230 + j; // position slaves, one-hot (230..233)
-export const POSM = (j: number) => 234 + j; // slave mirrors: left/right D taps (234..237)
-export const LEFTM = 238, RIGHTM = 239; // button-line mirrors (direction gates)
-export const ANYBM = 240; // either button, depth 1: feeds the delay stage
-export const ANYBM2 = 241; // depth 2 echo: master hold, + TWIN's window detector
-export const WIDM = 242, WIDM2 = 243; // wide-mode mirrors (WID slide) for the edge feeds
-export const POSRST = (x: number) => 244 + x; // 2 relays: the RESET tick re-homes POS
-export const TWIN = 246; // the release window (ANYBM down AND ANYBM2 still up): transfer NOW
-export const BOOTL = 247; // latches on the first press; its NC is the power-on home seed
-export const POSM2 = (j: number) => 248 + j; // 3 more slave mirrors: the wide taps' pos gates
+export const POSA = L8.POSA; // step masters (226..229)
+export const POSS = L8.POSS; // position slaves, one-hot (230..233)
+export const POSM = L8.POSM; // slave mirrors: left/right D taps (234..237)
+export const LEFTM = L8.LEFTM, RIGHTM = L8.RIGHTM; // button-line mirrors (direction gates)
+export const ANYBM = L8.ANYBM; // either button, depth 1: feeds the delay stage
+export const ANYBM2 = L8.ANYBM2; // depth 2 echo: master hold, + TWIN's window detector
+export const WIDM = L8.WIDM, WIDM2 = L8.WIDM2; // wide-mode mirrors (WID slide) for the edge feeds
+export const POSRST = L8.POSRST; // 2 relays: the RESET tick re-homes POS
+export const TWIN = L8.TWIN; // the release window (ANYBM down AND ANYBM2 still up): transfer NOW
+export const BOOTL = L8.BOOTL; // latches on the first press; its NC is the power-on home seed
+export const POSM2 = L8.POSM2; // 3 more slave mirrors: the wide taps' pos gates
 // increment 2 — lateral legality in contacts:
-export const MIRC = (r: number, h: number) => 251 + 2 * r + h; // rows 0..6 x2: token-row gates for the occupancy taps
-export const LEGINV = (j: number) => 265 + j; // "column j occupied at the token row" (rail coil); its changeover routes the step
-export const LEGINV2 = (k: number) => 267 + k; // k=2,3: second reads of columns 2,3 for the wide right-edge checks
-export const WIDM3 = 271, WIDM4 = 272; // wide-mode mirrors: the wide forks + the wall gate
+export const MIRC = L8.MIRC; // rows 0..6 x2: token-row gates for the occupancy taps
+export const LEGINV = L8.LEGINV; // "column j occupied at the token row" (rail coil); its changeover routes the step
+export const LEGINV2 = L8.LEGINV2; // k=2,3: second reads of columns 2,3 for the wide right-edge checks
+export const WIDM3 = L8.WIDM3, WIDM4 = L8.WIDM4; // wide-mode mirrors: the wide forks + the wall gate
 // increment 3a — the tall piece's TOP row refuses too:
-export const MIRCT = (r: number, h: number) => 273 + 2 * (r - 1) + h; // rows 1..6 x2: "token at r" reading row r-1 (273..284)
-export const LEGINVT = (j: number) => 285 + j; // "column j occupied one row ABOVE the token" (285..288)
-export const LEGINVT2 = (k: number) => 287 + k; // k=2,3: top second-reads for the 2x2's right edge (289,290)
-export const VMODEM = (p: number) => 291 + p; // vmode mirrors: the tall forks in the D-tap trees (291..294)
+export const MIRCT = L8.MIRCT; // rows 1..6 x2: "token at r" reading row r-1 (273..284)
+export const LEGINVT = L8.LEGINVT; // "column j occupied one row ABOVE the token" (285..288)
+export const LEGINVT2 = L8.LEGINVT2; // k=2,3: top second-reads for the 2x2's right edge (289,290)
+export const VMODEM = L8.VMODEM; // vmode mirrors: the tall forks in the D-tap trees (291..294)
 // the game-over latch (appended: the tall-well layout below stays stable)
-export const GOM = 295; // "token at row 0" mirror (chained off MIRC(0,1)'s coil jack)
-export const GAMEOVER = 296; // latches on any lock at row 0; its NC blocks START forever
-export const LKM2 = 297; // lock-master mirror: the +-fed lock scope for GAMEOVER's set
+export const GOM = L8.GOM; // "token at row 0" mirror (chained off MIRC(0,1)'s coil jack)
+export const GAMEOVER = L8.GAMEOVER; // latches on any lock at row 0; its NC blocks START forever
+export const LKM2 = L8.LKM2; // lock-master mirror: the +-fed lock scope for GAMEOVER's set
 // the score ring (0..9, one step per line clear — the token-ring pattern):
-export const SCR = (i: number, part: number) => 298 + 3 * i + part; // clk, master, slave per digit (298..327)
-export const SCBOOT = 328; // latches on the first clear; its NC is digit 0's power-on seed
+export const SCR = L8.SCR; // clk, master, slave per digit (298..327)
+export const SCBOOT = L8.SCBOOT; // latches on the first clear; its NC is digit 0's power-on seed
 // staggered pieces (S/Z — shapes increment 3b-1):
-export const PIECET = (j: number) => 329 + j; // the TOP-row mask bank (TOPMASK slides on the button machine)
-export const CUTC5 = 333, CUTC6 = 334; // colFanT's collapse cuts (the CUTC pattern for the T fan)
-export const STAGM = 335; // the STAG slide's mirror: phase 2 feeds colFanT (staggered) instead of colFan
-export const CUTB1 = 336, CUTB2 = 337; // sever the B fan during a staggered phase 2 (its closed gates bridge rails through colFan)
-export const CUTB3 = 338, CUTB4 = 339; // ...and the collision-tap side: the SECOND bridge (collideNode), rung 10's lesson verbatim
-export const CUTBD = 340; // one-hop delay for ALL the stagger cuts: they must outlive the gates/rails/readback at the release
+export const PIECET = L8.PIECET; // the TOP-row mask bank (TOPMASK slides on the button machine)
+export const CUTC5 = L8.CUTC5, CUTC6 = L8.CUTC6; // colFanT's collapse cuts (the CUTC pattern for the T fan)
+export const STAGM = L8.STAGM; // the STAG slide's mirror: phase 2 feeds colFanT (staggered) instead of colFan
+export const CUTB1 = L8.CUTB1, CUTB2 = L8.CUTB2; // sever the B fan during a staggered phase 2 (its closed gates bridge rails through colFan)
+export const CUTB3 = L8.CUTB3, CUTB4 = L8.CUTB4; // ...and the collision-tap side: the SECOND bridge (collideNode), rung 10's lesson verbatim
+export const CUTBD = L8.CUTBD; // one-hop delay for ALL the stagger cuts: they must outlive the gates/rails/readback at the release
 // the top collision term (shapes 3b-2): a staggered notch rests on stored content
-export const LEGB = (j: number) => 341 + j; // second reads of "col j occupied at the token row" (the legality rails)
-export const STAGM2 = 345; // second STAG mirror: the top collision term applies only in staggered mode
+export const LEGB = L8.LEGB; // second reads of "col j occupied at the token row" (the legality rails)
+export const STAGM2 = L8.STAGM2; // second STAG mirror: the top collision term applies only in staggered mode
 // the shape ring (3b-3a): a 6-state one-hot ring stepped by the UP button,
 // state order = the page's cycle (0=1x1, 1=2wide, 2=2tall, 3=O, 4=S, 5=Z).
 // the ring DERIVES the mode rails the operator slides drive, wiring into
@@ -159,15 +165,15 @@ export const STAGM2 = 345; // second STAG mirror: the top collision term applies
 // legally; a disagreement UNIONS, which is what real hardware would do).
 // slide-driven tests/procedures stay valid; state 0 = all rails off =
 // the slide defaults.
-export const SHR = (i: number, part: number) => 346 + 3 * i + part; // clk, master, slave per state (346..363)
-export const UPM = 364; // UP-button mirror: set1 clocks the ring, set2 K pulses SHBOOT (the CLEARPM pattern)
-export const SHBOOT = 365; // latches on the first UP; its NC seeds state 0 (the BOOTL idiom, private relay)
-export const SM = (k: number) => 366 + k; // S-state mirrors (366..369): 4 T-fan branches + WIDB/VMODE/STAGM rails
-export const ZM = (k: number) => 370 + k; // Z-state mirrors (370..373): same ledger as S
-export const OM = 374; // O-state mirror: WIDB + VMODE rails
-export const I2TM = 375; // 2-tall mirror: VMODE rail
-export const I2WM = 376; // 2-wide mirror: WIDB rail
-export const POSM3 = (k: number) => 377 + k; // T-fan pos mirrors: k=0 pos0, k=1,2 pos1, k=3 pos2 (377..380)
+export const SHR = L8.SHR; // clk, master, slave per state (346..363)
+export const UPM = L8.UPM; // UP-button mirror: set1 clocks the ring, set2 K pulses SHBOOT (the CLEARPM pattern)
+export const SHBOOT = L8.SHBOOT; // latches on the first UP; its NC seeds state 0 (the BOOTL idiom, private relay)
+export const SM = L8.SM; // S-state mirrors (366..369): 4 T-fan branches + WIDB/VMODE/STAGM rails
+export const ZM = L8.ZM; // Z-state mirrors (370..373): same ledger as S
+export const OM = L8.OM; // O-state mirror: WIDB + VMODE rails
+export const I2TM = L8.I2TM; // 2-tall mirror: VMODE rail
+export const I2WM = L8.I2WM; // 2-wide mirror: WIDB rail
+export const POSM3 = L8.POSM3; // T-fan pos mirrors: k=0 pos0, k=1,2 pos1, k=3 pos2 (377..380)
 // 3b-3b — the legality trees re-gated per the TRUE target top columns.
 // key fact: the existing tree checks are false ONLY one mode at a time:
 // every LEGINVT (point-1/left) check is correct for symmetric AND S
@@ -179,10 +185,10 @@ export const POSM3 = (k: number) => 377 + k; // T-fan pos mirrors: k=0 pos0, k=1
 // series hops: LTS = S-gated top reads of c-1, LTZ = Z-gated reads of
 // c+1/c+2, plus two pure BOUNDS checks (S cannot enter pos 0, Z cannot
 // enter pos 2 — an S/Z state mirror's NO straight to the return).
-export const LTS = (k: number) => 381 + k; // S-only top reads: k=0 col0, k=1 col1 (coil = rail AND S)
-export const LTZ = (k: number) => 383 + k; // Z-only top reads: k=0 col1, k=1 col2, k=2,3 col3
-export const SG = (k: number) => 387 + k; // S mirrors: SG(0) = the NOT-S coil gates, SG(1) = the LTS coil gates
-export const ZG = (k: number) => 389 + k; // Z mirrors: ZG(0,1) = NOT-Z coil gates, ZG(2,3) = LTZ gates + the Z bound
+export const LTS = L8.LTS; // S-only top reads: k=0 col0, k=1 col1 (coil = rail AND S)
+export const LTZ = L8.LTZ; // Z-only top reads: k=0 col1, k=1 col2, k=2,3 col3
+export const SG = L8.SG; // S mirrors: SG(0) = the NOT-S coil gates, SG(1) = the LTS coil gates
+export const ZG = L8.ZG; // Z mirrors: ZG(0,1) = NOT-Z coil gates, ZG(2,3) = LTZ gates + the Z bound
 // 3b-3c — UP-transition legality: the ring's clock feed conducts through
 // a check network instead of a plain wire. The energized MASTER (one-hot:
 // the current state's successor, sampled while the clock is low) names
@@ -227,19 +233,19 @@ export const shapeRange = (s: (typeof SHAPES)[number], cols: number) => ({
   min: Math.max(0, -s.bOff, s.tW > 0 ? -s.tOff : 0),
   max: Math.min(cols - s.bOff - s.bW, s.tW > 0 ? cols - s.tOff - s.tW : cols),
 });
-export const SHR2 = (i: number, part: number) => 415 + 3 * (i - 6) + part; // states 6..8: clk, master, slave (415..423)
-export const MMIR2 = (i: number) => 424 + (i - 6); // into-6..8 transition gates (424..426)
+export const SHR2 = L8.SHR2; // states 6..8: clk, master, slave (415..423)
+export const MMIR2 = L8.MMIR2; // into-6..8 transition gates (424..426)
 // POSM5 set map (7 pos0 + 7 pos1 uses): k=0 B-fan PIECE(2) + T-fan L1;
 // k=1 T-fan J1 + T1; k=2 into-6 p0 + into-7 p0; k=3 into-8 p0 + spare;
 // k=4..7 the same roles at pos1.
-export const POSM5 = (k: number) => 427 + k; // pos mirrors: k=0..3 pos0, k=4..7 pos1 (427..434)
-export const UTR2 = (k: number) => 435 + k; // more top-rail reads: k=0 col0, k=1 col1, k=2 col2 (435..437)
-export const TRP = 438; // the triple rail: L1|J1|T1
-export const TRPM = (k: number) => 439 + k; // TRP mirrors (439..440)
-export const L1M = (k: number) => 441 + k; // L1 state mirrors (441..442)
-export const J1M = (k: number) => 443 + k; // J1 state mirrors (443..444)
-export const T1M = (k: number) => 445 + k; // T1 state mirrors (445..446)
-export const WID3M = 447; // "the bottom grows a third column": the offset-2 taps' gate
+export const POSM5 = L8.POSM5; // pos mirrors: k=0..3 pos0, k=4..7 pos1 (427..434)
+export const UTR2 = L8.UTR2; // more top-rail reads: k=0 col0, k=1 col1, k=2 col2 (435..437)
+export const TRP = L8.TRP; // the triple rail: L1|J1|T1
+export const TRPM = L8.TRPM; // TRP mirrors (439..440)
+export const L1M = L8.L1M; // L1 state mirrors (441..442)
+export const J1M = L8.J1M; // J1 state mirrors (443..444)
+export const T1M = L8.T1M; // T1 state mirrors (445..446)
+export const WID3M = L8.WID3M; // "the bottom grows a third column": the offset-2 taps' gate
 // 3b-4b — TRIPLE STEERING: the legality trees re-class per top geometry
 // and the NS cut dies. the gate generalization: LEGINVT's checks are
 // correct for {sym, S, L1} (their target top CONTAINS the checked
@@ -249,15 +255,15 @@ export const WID3M = 447; // "the bottom grows a third column": the offset-2 tap
 // state-gated series hops (LTJ/LTT top reads, LTB3 the triple bottom's
 // entering col 3), plus TRPBND (a triple cannot right-step into pos 2).
 // left-into-2 keeps no triple legs: a triple is never at pos 3.
-export const ZJT = 448; // gate coil: Z|J1|T1 (feeds ZG(0,1), the NOT gates on LEGINVT)
-export const SLJ = 449; // gate coil: S|L1|J1 (feeds SG(0), the NOT gate on LEGINVT2)
-export const ZM2 = 450; // one more Z mirror (ZJT's Z contact)
-export const SM2 = 451; // one more S mirror (SLJ's S contact)
-export const J1M2 = 452, J1M3 = 453; // more J1 mirrors: gate feeds + the LTJ coil gates
-export const T1M2 = 454; // more T1 contacts: the LTT coil gates
-export const LTJ = (k: number) => 455 + k; // J1-only top reads: k=0 col2, k=1 col3
-export const LTT = (k: number) => 457 + k; // T1-only top reads: k=0 col1, k=1 col2
-export const LTB3 = 459; // triple-only bottom read of col 3 (the right step's entering column)
+export const ZJT = L8.ZJT; // gate coil: Z|J1|T1 (feeds ZG(0,1), the NOT gates on LEGINVT)
+export const SLJ = L8.SLJ; // gate coil: S|L1|J1 (feeds SG(0), the NOT gate on LEGINVT2)
+export const ZM2 = L8.ZM2; // one more Z mirror (ZJT's Z contact)
+export const SM2 = L8.SM2; // one more S mirror (SLJ's S contact)
+export const J1M2 = L8.J1M2, J1M3 = L8.J1M3; // more J1 mirrors: gate feeds + the LTJ coil gates
+export const T1M2 = L8.T1M2; // more T1 contacts: the LTT coil gates
+export const LTJ = L8.LTJ; // J1-only top reads: k=0 col2, k=1 col3
+export const LTT = L8.LTT; // T1-only top reads: k=0 col1, k=1 col2
+export const LTB3 = L8.LTB3; // triple-only bottom read of col 3 (the right step's entering column)
 // 3b-4c — the OVERHANG TRIO completes the 2-row box: 9 L2=(001,111)
 // B={p+2}, 10 J2=(100,111) B={p}, 11 T2=(010,111) B={p+1}, all with the
 // 3-wide TT top and range {0,1}. the base bottom column is CUT for
@@ -270,21 +276,21 @@ export const LTB3 = 459; // triple-only bottom read of col 3 (the right step's e
 // (L2-gated c+2) and T2B (T2-gated c+1), the shared top via LTOT
 // (TT-gated c+2 on the right step), and the pos-2 bound extends to TT.
 // the into-0 wrap gains its first check: T2 -> 1x1 uncovers (tok, p).
-export const SHR3 = (i: number, part: number) => 460 + 3 * (i - 9) + part; // states 9..11 (460..468)
-export const MMIR3 = (i: number) => 469 + (i - 9); // into-9..11 gates (469..471)
-export const TT = 472; // the triple-TOP rail: L2|J2|T2
-export const TTM = (k: number) => 473 + k; // TT mirrors (473..477)
-export const BCUT = 478; // the base-column cut (coil = L2|T2); set2 + BCUTM = the OVR bypasses
-export const BCUTM = 479;
-export const L2M = (k: number) => 480 + k; // L2 mirrors (480..482)
-export const J2M = 483; // J2 mirror
-export const T2M = (k: number) => 484 + k; // T2 mirrors (484..486)
-export const LTOT = 487; // TT-gated top read of col 3 (right-step entering top)
-export const LTOB = (k: number) => 488 + k; // L2-gated bottom reads: k=0 col2, k=1 col3
-export const T2B = (k: number) => 490 + k; // T2-gated bottom reads: k=0 col1, k=1 col2
-export const UTR3 = 492; // one more top-col3 read (the T1->L2 transition)
-export const LEGB3 = (k: number) => 493 + k; // more bottom reads: k=0 col1, k=1 col2, k=2 col0
-export const POSM6 = (k: number) => 496 + k; // pos mirrors: k=0..2 pos0, k=3..5 pos1 (496..501)
+export const SHR3 = L8.SHR3; // states 9..11 (460..468)
+export const MMIR3 = L8.MMIR3; // into-9..11 gates (469..471)
+export const TT = L8.TT; // the triple-TOP rail: L2|J2|T2
+export const TTM = L8.TTM; // TT mirrors (473..477)
+export const BCUT = L8.BCUT; // the base-column cut (coil = L2|T2); set2 + BCUTM = the OVR bypasses
+export const BCUTM = L8.BCUTM;
+export const L2M = L8.L2M; // L2 mirrors (480..482)
+export const J2M = L8.J2M; // J2 mirror
+export const T2M = L8.T2M; // T2 mirrors (484..486)
+export const LTOT = L8.LTOT; // TT-gated top read of col 3 (right-step entering top)
+export const LTOB = L8.LTOB; // L2-gated bottom reads: k=0 col2, k=1 col3
+export const T2B = L8.T2B; // T2-gated bottom reads: k=0 col1, k=1 col2
+export const UTR3 = L8.UTR3; // one more top-col3 read (the T1->L2 transition)
+export const LEGB3 = L8.LEGB3; // more bottom reads: k=0 col1, k=1 col2, k=2 col0
+export const POSM6 = L8.POSM6; // pos mirrors: k=0..2 pos0, k=3..5 pos1 (496..501)
 // 3b-5 — THE MACHINE TICKS ITSELF: a two-relay slow-release oscillator
 // on real capacitors. TOSC's coil parallels a paralleled cap bank and is
 // fed through TDRV's NC; TDRV is fed through TOSC's NO; TDRV's second
@@ -299,16 +305,16 @@ export const POSM6 = (k: number) => 496 + k; // pos mirrors: k=0..2 pos0, k=3..5
 // TOSC's own section: the operator chooses self-play. Period: a few
 // hundred ms with four paralleled sections at 100ms steps (measured in
 // the oscillator test; more sections or larger steps slow it further).
-export const TOSC = 502; // the timing relay (coil || cap bank)
-export const TDRV = 503; // the driver: follows TOSC, its set2 drives the tick net
-export const MMIR = (i: number) => 393 + i; // master mirrors: gate the into-state-i branch (393..398)
-export const POSM4 = (k: number) => 399 + k; // pos mirrors for the branches: k=0 pos0, k=1,2 pos1, k=3,4 pos2, k=5 pos3 (399..404)
+export const TOSC = L8.TOSC; // the timing relay (coil || cap bank)
+export const TDRV = L8.TDRV; // the driver: follows TOSC, its set2 drives the tick net
+export const MMIR = L8.MMIR; // master mirrors: gate the into-state-i branch (393..398)
+export const POSM4 = L8.POSM4; // pos mirrors for the branches: k=0 pos0, k=1,2 pos1, k=3,4 pos2, k=5 pos3 (399..404)
 // (POSM4(5) exists because NOTHING on POSM(3) was borrowable: its L arm
 // IS the right-press sample bus and its K is the edge self-loop — tying
 // a check node there let a join backfeed fire the D-tap trees and wipe
 // the register to [1,1,1,1], caught by the ring walk test mid-build)
-export const LEGB2 = (k: number) => 405 + k; // second bottom-rail reads for cols 1,2,3 (405..407)
-export const UTR = (k: number) => 408 + k; // top-rail reads: k=0 col0, k=1,2 col1, k=3,4 col2, k=5,6 col3 (408..414)
+export const LEGB2 = L8.LEGB2; // second bottom-rail reads for cols 1,2,3 (405..407)
+export const UTR = L8.UTR; // top-rail reads: k=0 col0, k=1,2 col1, k=3,4 col2, k=5,6 col3 (408..414)
 // (re-homing on the spawn tick would flip the register mid-tick under a
 // merged spawn+lock; the reset tick is stable long before any spawn)
 
@@ -317,11 +323,11 @@ export const UTR = (k: number) => 408 + k; // top-rail reads: k=0 col0, k=1,2 co
 // free. (They lived on m40 through the piece rung, sharing sections with
 // relays whose + jacks HAPPENED to be unused; the 12-row layout landed
 // TWIN's + on the shared section and the capacity auditor caught it.)
-export const LEFTBTN = { button: 3, machine: 84 };
-export const RIGHTBTN = { button: 4, machine: 84 };
-export const UPBTN = { button: 2, machine: 84 }; // steps the shape ring (press+release = one step)
-export const WIDSLIDE = { slide: 5, machine: 84 };
-export const MACHINES = 85; // relays through m83.3 + the dedicated button machine m84; m36's coms serve as the junctions
+export const LEFTBTN = { button: 3, machine: L8.btnMachine };
+export const RIGHTBTN = { button: 4, machine: L8.btnMachine };
+export const UPBTN = { button: 2, machine: L8.btnMachine }; // steps the shape ring (press+release = one step)
+export const WIDSLIDE = { slide: 5, machine: L8.btnMachine };
+export const MACHINES = L8.machines; // the default build: the relay machines + the dedicated button machine
 
 // ---- the ROWS-parameterized layout (rung 11 groundwork) ----
 // The same allocation map as the exported constants, laid out sequentially
@@ -657,93 +663,6 @@ export function tetrisLayout(rows: number, cols = 4): TetrisLayout {
   for (let k = 0; k < 6; k++) claim('POSM6', POSM6(k));
   claim('TOSC/TDRV', TOSC, TDRV);
 
-  // the parameterized layout must reproduce the hand-laid map exactly at
-  // the default geometry — every scalar, every function over its domain,
-  // and the machine count
-  const L = tetrisLayout(8);
-  const eq = (name: string, a: number, b: number) => {
-    if (a !== b) throw new Error(`layout(8).${name} = ${a}, expected ${b}`);
-  };
-  eq('A0', L.A0, A0); eq('A0m', L.A0m, A0m); eq('A1', L.A1, A1); eq('A2', L.A2, A2);
-  for (let r = 0; r < 8; r++) for (let k = 0; k < 4; k++) eq('W', L.W(r, k), W(r, k));
-  for (let r = 0; r < 8; r++) for (let j = 0; j < 4; j++) eq('CELL', L.CELL(r, j), CELL(r, j));
-  for (let i = 0; i < 8; i++) for (let pt = 0; pt < 3; pt++) eq('RING', L.RING(i, pt), RING(i, pt));
-  for (let r = 0; r < 8; r++) { eq('MIRA', L.MIRA(r), MIRA(r)); eq('MIRB', L.MIRB(r), MIRB(r)); eq('MIRB2', L.MIRB2(r), MIRB2(r)); }
-  for (let x = 0; x < 4; x++) { eq('RESETM', L.RESETM(x), RESETM(x)); eq('PRESSCUT', L.PRESSCUT(x), PRESSCUT(x)); eq('P2CUT', L.P2CUT(x), P2CUT(x)); }
-  eq('COLLIDE', L.COLLIDE, COLLIDE); eq('COLLIDEM', L.COLLIDEM, COLLIDEM); eq('LKM', L.LKM, LKM); eq('RSTM', L.RSTM, RSTM);
-  eq('SPAWN', L.SPAWN, SPAWN); eq('SPAWNCLR', L.SPAWNCLR, SPAWNCLR); eq('CLEARP', L.CLEARP, CLEARP);
-  for (let j = 0; j < 4; j++) { eq('LINE', L.LINE(j), LINE(j)); eq('PIECE', L.PIECE(j), PIECE(j)); eq('POSA', L.POSA(j), POSA(j)); eq('POSS', L.POSS(j), POSS(j)); eq('POSM', L.POSM(j), POSM(j)); eq('LEGINV', L.LEGINV(j), LEGINV(j)); eq('LEGINVT', L.LEGINVT(j), LEGINVT(j)); eq('VMODEM', L.VMODEM(j), VMODEM(j)); }
-  eq('LKS', L.LKS, LKS); eq('TICKM', L.TICKM, TICKM); eq('COLLIDEM2', L.COLLIDEM2, COLLIDEM2); eq('READGATE', L.READGATE, READGATE);
-  eq('RAILGATE2', L.RAILGATE2, RAILGATE2); eq('RSTM2', L.RSTM2, RSTM2); eq('CPSET', L.CPSET, CPSET); eq('VMODE', L.VMODE, VMODE);
-  for (let r = 1; r <= 7; r++) eq('TOPW', L.TOPW(r), TOPW(r));
-  eq('P2M', L.P2M, P2M); eq('P2S', L.P2S, P2S); eq('P2CLR', L.P2CLR, P2CLR); eq('P2GATE', L.P2GATE, P2GATE); eq('P2COL', L.P2COL, P2COL); eq('TICKM2', L.TICKM2, TICKM2);
-  eq('LINEDLY', L.LINEDLY, LINEDLY);
-  for (let t = 1; t <= 7; t++) {
-    eq('ELEVC', L.ELEVC(t), ELEVC(t)); eq('ELEVA', L.ELEVA(t), ELEVA(t)); eq('ELEVSL', L.ELEVSL(t), ELEVSL(t));
-    eq('SEEDM', L.SEEDM(t), SEEDM(t)); eq('ELEVW1', L.ELEVW1(t), ELEVW1(t)); eq('ELEVW2', L.ELEVW2(t), ELEVW2(t));
-  }
-  eq('CLEARPM', L.CLEARPM, CLEARPM); eq('LANE', L.LANE, LANE); eq('TICKM3', L.TICKM3, TICKM3); eq('TGM', L.TGM, TGM); eq('TGS', L.TGS, TGS);
-  eq('CGA', L.CGA, CGA); eq('CGB', L.CGB, CGB); eq('CGB2', L.CGB2, CGB2); eq('CUTC1', L.CUTC1, CUTC1); eq('CUTC2', L.CUTC2, CUTC2);
-  for (let k = 0; k <= 5; k++) eq('JUNC', L.JUNC(k), JUNC(k));
-  eq('TG2M', L.TG2M, TG2M); eq('TG2S', L.TG2S, TG2S); eq('CUTC3', L.CUTC3, CUTC3); eq('CUTC4', L.CUTC4, CUTC4);
-  eq('LEFTM', L.LEFTM, LEFTM); eq('RIGHTM', L.RIGHTM, RIGHTM); eq('ANYBM', L.ANYBM, ANYBM); eq('ANYBM2', L.ANYBM2, ANYBM2);
-  eq('WIDM', L.WIDM, WIDM); eq('WIDM2', L.WIDM2, WIDM2); eq('WIDM3', L.WIDM3, WIDM3); eq('WIDM4', L.WIDM4, WIDM4);
-  for (let x = 0; x < 2; x++) eq('POSRST', L.POSRST(x), POSRST(x));
-  eq('TWIN', L.TWIN, TWIN); eq('BOOTL', L.BOOTL, BOOTL);
-  for (let j = 0; j < 3; j++) eq('POSM2', L.POSM2(j), POSM2(j));
-  for (let r = 0; r <= 6; r++) { eq('MIRC0', L.MIRC(r, 0), MIRC(r, 0)); eq('MIRC1', L.MIRC(r, 1), MIRC(r, 1)); }
-  for (let r = 1; r <= 6; r++) { eq('MIRCT0', L.MIRCT(r, 0), MIRCT(r, 0)); eq('MIRCT1', L.MIRCT(r, 1), MIRCT(r, 1)); }
-  eq('LEGINV2(2)', L.LEGINV2(2), LEGINV2(2)); eq('LEGINV2(3)', L.LEGINV2(3), LEGINV2(3));
-  eq('LEGINVT2(2)', L.LEGINVT2(2), LEGINVT2(2)); eq('LEGINVT2(3)', L.LEGINVT2(3), LEGINVT2(3));
-  eq('GOM', L.GOM, GOM); eq('GAMEOVER', L.GAMEOVER, GAMEOVER); eq('LKM2', L.LKM2, LKM2);
-  for (let i = 0; i < 10; i++)
-    for (let pt = 0; pt < 3; pt++) eq('SCR', L.SCR(i, pt), SCR(i, pt));
-  eq('SCBOOT', L.SCBOOT, SCBOOT);
-  for (let j = 0; j < 4; j++) eq('PIECET', L.PIECET(j), PIECET(j));
-  eq('CUTC5', L.CUTC5, CUTC5); eq('CUTC6', L.CUTC6, CUTC6); eq('STAGM', L.STAGM, STAGM); eq('CUTB1', L.CUTB1, CUTB1); eq('CUTB2', L.CUTB2, CUTB2); eq('CUTB3', L.CUTB3, CUTB3); eq('CUTB4', L.CUTB4, CUTB4); eq('CUTBD', L.CUTBD, CUTBD);
-  for (let j = 0; j < 4; j++) eq('LEGB', L.LEGB(j), LEGB(j));
-  eq('STAGM2', L.STAGM2, STAGM2);
-  for (let i = 0; i < 6; i++)
-    for (let pt = 0; pt < 3; pt++) eq('SHR', L.SHR(i, pt), SHR(i, pt));
-  eq('UPM', L.UPM, UPM); eq('SHBOOT', L.SHBOOT, SHBOOT);
-  for (let k = 0; k < 4; k++) { eq('SM', L.SM(k), SM(k)); eq('ZM', L.ZM(k), ZM(k)); eq('POSM3', L.POSM3(k), POSM3(k)); }
-  eq('OM', L.OM, OM); eq('I2TM', L.I2TM, I2TM); eq('I2WM', L.I2WM, I2WM);
-  eq('LTS', L.LTS(0), LTS(0)); eq('LTS', L.LTS(1), LTS(1));
-  for (let k = 0; k < 4; k++) { eq('LTZ', L.LTZ(k), LTZ(k)); eq('ZG', L.ZG(k), ZG(k)); }
-  eq('SG', L.SG(0), SG(0)); eq('SG', L.SG(1), SG(1));
-  for (let i = 0; i < 6; i++) eq('MMIR', L.MMIR(i), MMIR(i));
-  for (let k = 0; k < 6; k++) eq('POSM4', L.POSM4(k), POSM4(k));
-  for (let k = 0; k < 3; k++) eq('LEGB2', L.LEGB2(k), LEGB2(k));
-  for (let k = 0; k < 7; k++) eq('UTR', L.UTR(k), UTR(k));
-  for (let i = 6; i < 9; i++)
-    for (let pt = 0; pt < 3; pt++) eq('SHR2', L.SHR2(i, pt), SHR2(i, pt));
-  for (let i = 6; i < 9; i++) eq('MMIR2', L.MMIR2(i), MMIR2(i));
-  for (let k = 0; k < 8; k++) eq('POSM5', L.POSM5(k), POSM5(k));
-  for (let k = 0; k < 3; k++) eq('UTR2', L.UTR2(k), UTR2(k));
-  eq('TRP', L.TRP, TRP); eq('TRPM', L.TRPM(0), TRPM(0)); eq('TRPM', L.TRPM(1), TRPM(1));
-  eq('L1M', L.L1M(0), L1M(0)); eq('J1M', L.J1M(0), J1M(0)); eq('T1M', L.T1M(0), T1M(0));
-  eq('WID3M', L.WID3M, WID3M);
-  eq('ZJT', L.ZJT, ZJT); eq('SLJ', L.SLJ, SLJ); eq('ZM2', L.ZM2, ZM2); eq('SM2', L.SM2, SM2);
-  eq('J1M2', L.J1M2, J1M2); eq('J1M3', L.J1M3, J1M3); eq('T1M2', L.T1M2, T1M2);
-  eq('LTJ', L.LTJ(0), LTJ(0)); eq('LTJ', L.LTJ(1), LTJ(1));
-  eq('LTT', L.LTT(0), LTT(0)); eq('LTT', L.LTT(1), LTT(1));
-  eq('LTB3', L.LTB3, LTB3);
-  for (let i = 9; i < 12; i++)
-    for (let pt = 0; pt < 3; pt++) eq('SHR3', L.SHR3(i, pt), SHR3(i, pt));
-  for (let i = 9; i < 12; i++) eq('MMIR3', L.MMIR3(i), MMIR3(i));
-  eq('TT', L.TT, TT);
-  for (let k = 0; k < 5; k++) eq('TTM', L.TTM(k), TTM(k));
-  eq('BCUT', L.BCUT, BCUT); eq('BCUTM', L.BCUTM, BCUTM);
-  for (let k = 0; k < 3; k++) { eq('L2M', L.L2M(k), L2M(k)); eq('T2M', L.T2M(k), T2M(k)); eq('LEGB3', L.LEGB3(k), LEGB3(k)); }
-  eq('J2M', L.J2M, J2M);
-  eq('LTOT', L.LTOT, LTOT); eq('LTOB', L.LTOB(0), LTOB(0)); eq('LTOB', L.LTOB(1), LTOB(1));
-  eq('T2B', L.T2B(0), T2B(0)); eq('T2B', L.T2B(1), T2B(1)); eq('UTR3', L.UTR3, UTR3);
-  for (let k = 0; k < 6; k++) eq('POSM6', L.POSM6(k), POSM6(k));
-  eq('TOSC', L.TOSC, TOSC); eq('TDRV', L.TDRV, TDRV);
-  eq('machines', L.machines, MACHINES);
-  eq('btnMachine', L.btnMachine, LEFTBTN.machine);
-  eq('btnMachine2', L.btnMachine, RIGHTBTN.machine);
-  eq('btnMachine3', L.btnMachine, WIDSLIDE.machine);
 }
 
 export function tetrisCircuit(rows = 8, cols = 4): {

--- a/src/simulator/tests/contact-alloc.test.ts
+++ b/src/simulator/tests/contact-alloc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MirrorBank } from '../../circuits/contact-alloc';
+import { GatedReadPool, MirrorBank } from '../../circuits/contact-alloc';
 
 // jack-name helpers mirroring the circuit file's conventions
 const R = (n: number, jack: string) => `m${Math.floor(n / 6)}.${(n % 6) + 1}${jack}`;
@@ -32,6 +32,24 @@ describe('the contact allocator (wider-well emitter 0)', () => {
     const bank = new MirrorBank({ name: 'TESTM', source: 0, base: 6, capacity: 2, w, R, minusOf });
     for (let i = 0; i < 4; i++) bank.request('gate');
     expect(() => bank.request('gate')).toThrowError(/TESTM: bank exhausted \(2 mirrors \/ 4 sets; request #5\)/);
+  });
+
+  it('gated reads: rail through the gate contact into the coil; extend chains', () => {
+    const w: string[] = [];
+    const pool = new GatedReadPool({ name: 'LTX', source: null, base: 40, capacity: 2, w, R, minusOf });
+    const gate = { relay: 12, set: 1 as const, arm: 'H', no: 'G', nc: 'J' };
+    const rd = pool.read('m9.M10', gate);
+    expect(rd.relay).toBe(40);
+    expect(w).toEqual([
+      `m9.M10/${R(12, 'H')}`,
+      `${R(12, 'G')}/${R(40, 'E')}`,
+      `${R(40, 'F')}/${minusOf(40)}`,
+    ]);
+    const more = pool.extend(rd);
+    expect(more.relay).toBe(41);
+    expect(w.slice(3)).toEqual([`${R(40, 'E')}/${R(41, 'E')}`, `${R(41, 'F')}/${minusOf(41)}`]);
+    expect(pool.spent()).toBe(2);
+    expect(() => pool.read('m9.M11', gate)).toThrowError(/LTX: pool exhausted/);
   });
 
   it('source: null banks leave the first coil feed to the caller', () => {

--- a/src/simulator/tests/contact-alloc.test.ts
+++ b/src/simulator/tests/contact-alloc.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { MirrorBank } from '../../circuits/contact-alloc';
+
+// jack-name helpers mirroring the circuit file's conventions
+const R = (n: number, jack: string) => `m${Math.floor(n / 6)}.${(n % 6) + 1}${jack}`;
+const minusOf = (n: number) => `m${Math.floor(n / 6)}.${(n % 6) + 1}-`;
+
+describe('the contact allocator (wider-well emitter 0)', () => {
+  it('mints mirrors on demand, chains coils, hands out sets in order', () => {
+    const w: string[] = [];
+    const bank = new MirrorBank({ name: 'TESTM', source: 10, base: 20, capacity: 3, w, R, minusOf });
+    // no wires until the first request forces a mint
+    expect(w).toEqual([]);
+    const a = bank.request('gate');
+    expect(a).toEqual({ relay: 20, set: 1, arm: 'H', no: 'G', nc: 'J' });
+    // first mirror: coil parallels the SOURCE's coil net, F to its minus
+    expect(w).toEqual([`${R(10, 'E')}/${R(20, 'E')}`, `${R(20, 'F')}/${minusOf(20)}`]);
+    const b = bank.request('changeover');
+    expect(b).toEqual({ relay: 20, set: 2, arm: 'L', no: 'K', nc: 'N' });
+    expect(w.length, 'second set of the same mirror needs no new coil').toBe(2);
+    const c = bank.request('gate');
+    expect(c.relay, 'third set mints mirror #2').toBe(21);
+    expect(c.set).toBe(1);
+    // mirror #2 chains at the coil jacks off mirror #1
+    expect(w.slice(2)).toEqual([`${R(20, 'E')}/${R(21, 'E')}`, `${R(21, 'F')}/${minusOf(21)}`]);
+    expect(bank.spent()).toMatchObject({ relays: 2, sets: 3 });
+    expect(bank.spent().kinds).toEqual(['gate', 'changeover', 'gate']);
+  });
+
+  it('throws at capacity instead of silently overflowing', () => {
+    const w: string[] = [];
+    const bank = new MirrorBank({ name: 'TESTM', source: 0, base: 6, capacity: 2, w, R, minusOf });
+    for (let i = 0; i < 4; i++) bank.request('gate');
+    expect(() => bank.request('gate')).toThrowError(/TESTM: bank exhausted \(2 mirrors \/ 4 sets; request #5\)/);
+  });
+
+  it('source: null banks leave the first coil feed to the caller', () => {
+    const w: string[] = [];
+    const bank = new MirrorBank({ name: 'GATED', source: null, base: 30, capacity: 2, w, R, minusOf });
+    bank.request('gate');
+    // only the F/minus wire: the caller wires the gated coil feed itself
+    expect(w).toEqual([`${R(30, 'F')}/${minusOf(30)}`]);
+    bank.request('gate');
+    bank.request('gate');
+    // the SECOND mirror still chains off the first (one gated feed serves the bank)
+    expect(w.slice(1)).toEqual([`${R(30, 'E')}/${R(31, 'E')}`, `${R(31, 'F')}/${minusOf(31)}`]);
+  });
+});

--- a/src/simulator/tests/multivac-mini-tetris.test.ts
+++ b/src/simulator/tests/multivac-mini-tetris.test.ts
@@ -2099,6 +2099,76 @@ describe('Multivac: mini-tetris (67 machines at the classic 8 rows)', () => {
     expect(g.m.getState().alerts).toEqual([]);
   });
 
+  // 3b-5: THE MACHINE TICKS ITSELF — a two-relay slow-release oscillator
+  // on the real capacitor bank drives the tick net under stepTime. The
+  // transition solve BUZZES (a real relay oscillator buzzes; chatter
+  // pins de-energized and the game machinery rides through it, the
+  // device-verified class), leaving one clean tick-LOW step per cycle.
+  it('the machine ticks itself: capacitor gravity (fast)', { timeout: 1800000 }, () => {
+    setSolverEngine('fast');
+    const g = makeGame();
+    const auto = (on: boolean) =>
+      g.m.setSlide(TETRIS_IO.auto.slide, on ? 'right' : 'left', TETRIS_IO.auto.machine);
+    g.pressStart();
+    // AUTO off: time passes, nothing ticks, no token ever spawns
+    for (let t = 0; t < 10; t++) g.m.stepTime(100);
+    expect(g.tokenAt(), 'no oscillator, no ticks').toEqual([]);
+    // AUTO on: the piece falls, locks, runs its own bookkeeping, and the
+    // next piece spawns — hands off (START was pressed once, above)
+    auto(true);
+    let steered = false;
+    for (let t = 0; t < 140 && g.row(7) === 0; t++) {
+      g.m.stepTime(100);
+      // steer mid-fall once, during self-play
+      if (!steered && g.tokenAt().length === 1 && g.tokenAt()[0] >= 2) {
+        g.pressBtn(TETRIS_IO.right);
+        steered = true;
+        expect(g.posAt(), 'steering works during self-play').toBe(1);
+      }
+    }
+    expect(g.row(7), 'the steered piece locked at column 1, hands off').toBe(0b0010);
+    // keep time flowing until the SECOND piece lands on the floor too
+    for (let t = 0; t < 200 && g.row(7) === 0b0010; t++) g.m.stepTime(100);
+    expect(g.row(7) & 0b0001, 'the re-homed second piece landed at col 0').toBe(0b0001);
+    // AUTO off freezes gravity (the current token, if any, hangs forever)
+    auto(false);
+    const frozen = g.tokenAt();
+    for (let t = 0; t < 15; t++) g.m.stepTime(100);
+    expect(g.tokenAt(), 'no oscillator, no gravity').toEqual(frozen);
+    expect(g.m.getState().alerts).toEqual([]);
+  });
+
+  // ...and the oscillator itself is engine-exact: the standalone pair
+  // produces identical edges and cap voltages under sparse and fast.
+  it('the oscillator: sparse and fast agree edge for edge', { timeout: 600000 }, () => {
+    const wires = [
+      'm0.1+/m0.1S', 'm0.1T/m0.2H', 'm0.2J/m0.1E', 'm0.1F/m0.1-',
+      'm0.1E/m0.1cap',
+      'm0.1+/m0.1H', 'm0.1G/m0.2E', 'm0.2F/m0.2-',
+    ];
+    const run = (engine: 'sparse' | 'fast') => {
+      setSolverEngine(engine);
+      const m = new MinivacSimulator(wires, false, 1);
+      m.initialize();
+      m.setSlide(1, 'right', 0);
+      const edges: string[] = [];
+      let last = m.getMachineState(0).relays[1];
+      for (let t = 0; t < 80; t++) {
+        m.stepTime(25);
+        const d = m.getMachineState(0).relays[1];
+        if (d !== last) {
+          edges.push(`${t}:${d ? 1 : 0}:${m.getCapVoltage(1).toFixed(3)}`);
+          last = d;
+        }
+      }
+      return edges;
+    };
+    const sparse = run('sparse');
+    const fast = run('fast');
+    expect(sparse.length, 'it oscillates').toBeGreaterThan(10);
+    expect(fast, 'edge-for-edge parity').toEqual(sparse);
+  });
+
   // the score ring: a one-hot decimal digit stepped once per line clear
   // (the token-ring pattern with CLEARP as the clock; digit 0 seeded at
   // power-on through SCBOOT, which latches away on the first clear). The

--- a/src/simulator/tests/multivac-mini-tetris.test.ts
+++ b/src/simulator/tests/multivac-mini-tetris.test.ts
@@ -355,7 +355,7 @@ function dropVertical(
   collapseTicks(g, cleared, model, label);
 }
 
-describe('Multivac: mini-tetris (67 machines at the classic 8 rows)', () => {
+describe('Multivac: mini-tetris (85 machines at the classic 8 rows)', () => {
   it('gravity, stacking, and a line clear (fast)', { timeout: 1500000 }, () => {
     setSolverEngine('fast');
     const g = makeGame();
@@ -2136,6 +2136,84 @@ describe('Multivac: mini-tetris (67 machines at the classic 8 rows)', () => {
     for (let t = 0; t < 15; t++) g.m.stepTime(100);
     expect(g.tokenAt(), 'no oscillator, no gravity').toEqual(frozen);
     expect(g.m.getState().alerts).toEqual([]);
+  });
+
+  // the oscillator's operating rules, machine-level (the page encodes them
+  // as operator guards). Under stepTime the cycle is: one buzz solve
+  // (chatter-pinned, TDRV reads low, cap recharged to ~12V) then a few
+  // beats of slow release with TDRV holding the tick line HIGH until the
+  // cap falls below dropout. Two consequences, both verified on the sim:
+  // a START pressed into the held-high line dissipates (the arm needs a
+  // low line to survive to the next rising edge — same physics as
+  // pressing START while holding the tick slide), and taking the AUTO
+  // slide back mid-release freezes the line high forever (time stops, the
+  // cap never drains) — manual ticks and STARTs are all dead against it.
+  it('the oscillator gaps: START and the AUTO slide need the tick-low beat (fast)', { timeout: 1800000 }, () => {
+    setSolverEngine('fast');
+    const auto = (g: ReturnType<typeof makeGame>, on: boolean) =>
+      g.m.setSlide(TETRIS_IO.auto.slide, on ? 'right' : 'left', TETRIS_IO.auto.machine);
+    const drv = (g: ReturnType<typeof makeGame>) =>
+      g.m.getMachineState(TETRIS_IO.oscRelay.machine).relays[TETRIS_IO.oscRelay.index] ? 1 : 0;
+    const stepTo = (g: ReturnType<typeof makeGame>, want: number) => {
+      let n = 0;
+      while (drv(g) !== want && n++ < 30) g.m.stepTime(65);
+      expect(drv(g), `found a beat settled tick-${want ? 'high' : 'low'}`).toBe(want);
+    };
+    const g = makeGame();
+    auto(g, true);
+    // (1) a START pressed into the held-high line dissipates — and leaves
+    // NO latent arm behind (no surprise spawn beats later)
+    stepTo(g, 1);
+    g.pressStart();
+    for (let t = 0; t < 30; t++) g.m.stepTime(100);
+    expect(g.tokenAt(), 'the arm dissipated, nothing latent').toEqual([]);
+    // (2) the same machine spawns from a beat that settled tick-low
+    stepTo(g, 0);
+    g.pressStart();
+    let spawned = false;
+    for (let t = 0; t < 10 && !spawned; t++) {
+      g.m.stepTime(100);
+      spawned = g.tokenAt().length === 1;
+    }
+    expect(spawned, 'a tick-low START spawns').toBe(true);
+    // (3) steering is level-read, not edge-consumed: a press into the
+    // high line still lands, and nothing corrupts
+    stepTo(g, 1);
+    const p = g.posAt();
+    g.pressBtn(TETRIS_IO.right);
+    expect(g.posAt(), 'the tick-high step landed').toBe(p + 1);
+    expect(g.tokenAt().length, 'the token survived the tick-high press').toBe(1);
+    // (4) the WRONG way to stop: cutting the feed at a tick-high beat and
+    // freezing time right there wedges the line high — no manual tick can
+    // make an edge against it, so the mid-fall token hangs forever
+    stepTo(g, 1);
+    auto(g, false);
+    const hung = g.tokenAt();
+    for (let i = 0; i < 3; i++) {
+      g.m.setSlide(5, 'right', 1); // raw slide cycles: tick()'s clean-run
+      g.m.setSlide(5, 'left', 1); // asserts are not the contract here
+    }
+    expect(g.tokenAt(), 'tick line frozen high: manual ticks are dead').toEqual(hung);
+    expect(drv(g), 'the driver relay is stuck up').toBe(1);
+    // (5) AUTO off the right way, on a fresh machine: cut the feed FIRST,
+    // keep time flowing until the driver relay stays down (the cap drains
+    // through the coil in a couple of beats), and only then stop the
+    // clock — manual play works from there
+    const h = makeGame();
+    auto(h, true);
+    stepTo(h, 1);
+    auto(h, false);
+    let low = 0;
+    for (let i = 0; i < 20 && low < 2; i++) {
+      h.m.stepTime(65);
+      low = drv(h) ? 0 : low + 1;
+    }
+    expect(low, 'the cap drained; the driver relay stays down').toBe(2);
+    h.pressStart();
+    h.tick();
+    expect(h.tokenAt(), 'the drained machine spawns manually').toEqual([0]);
+    h.tick();
+    expect(h.tokenAt(), 'and ticks manually').toEqual([1]);
   });
 
   // ...and the oscillator itself is engine-exact: the standalone pair

--- a/src/simulator/tests/shape-geometry.test.ts
+++ b/src/simulator/tests/shape-geometry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { SHAPES, shapeRange, stepEntering } from '../../circuits/multivac-mini-tetris';
+
+// the geometry the wider-well emitters build from. the step vectors are
+// pinned to the check tables that were VERIFIED against three hand-laid
+// trees (_notes/wider-well.md): offsets are from the TARGET position q.
+const byLabel = (l: string) => {
+  const s = SHAPES.find((x) => x.label === l);
+  if (!s) throw new Error(l);
+  return s;
+};
+
+describe('shape geometry (wider-well emitter input)', () => {
+  it('step entering offsets match the verified check tables', () => {
+    // S right: enters bottom q+1, top q (the b3 t2 at q=2 case)
+    expect(stepEntering(byLabel('S'), 1)).toEqual({ b: 1, t: 0 });
+    // Z right: bottom q+1, top q+2 (the NOT-Z-gated LTZ path)
+    expect(stepEntering(byLabel('Z'), 1)).toEqual({ b: 1, t: 2 });
+    // narrow flat: bottom q only
+    expect(stepEntering(byLabel('1x1'), 1)).toEqual({ b: 0, t: null });
+    expect(stepEntering(byLabel('1x1'), -1)).toEqual({ b: 0, t: null });
+    // triples right: bottom q+2; stems at their tOff+tW-1
+    expect(stepEntering(byLabel('L'), 1)).toEqual({ b: 2, t: 0 });
+    expect(stepEntering(byLabel('J'), 1)).toEqual({ b: 2, t: 2 });
+    expect(stepEntering(byLabel('T'), 1)).toEqual({ b: 2, t: 1 });
+    // overhangs: offset single bottoms under 3-wide tops
+    expect(stepEntering(byLabel('L flip'), 1)).toEqual({ b: 2, t: 2 });
+    expect(stepEntering(byLabel('J flip'), 1)).toEqual({ b: 0, t: 2 });
+    expect(stepEntering(byLabel('T flip'), 1)).toEqual({ b: 1, t: 2 });
+    // left steps read the low edge
+    expect(stepEntering(byLabel('S'), -1)).toEqual({ b: 0, t: -1 });
+    expect(stepEntering(byLabel('L flip'), -1)).toEqual({ b: 2, t: 0 });
+  });
+
+  it('ranges at 4 and 6 match the tables', () => {
+    const r4 = (l: string) => shapeRange(byLabel(l), 4);
+    const r6 = (l: string) => shapeRange(byLabel(l), 6);
+    expect(r4('S')).toEqual({ min: 1, max: 2 });
+    expect(r4('Z')).toEqual({ min: 0, max: 1 });
+    expect(r4('L flip')).toEqual({ min: 0, max: 1 });
+    expect(r4('1x1')).toEqual({ min: 0, max: 3 });
+    expect(r6('S')).toEqual({ min: 1, max: 4 });
+    expect(r6('T')).toEqual({ min: 0, max: 3 });
+    expect(r6('2x2 square')).toEqual({ min: 0, max: 4 });
+  });
+});

--- a/src/tetris-main.ts
+++ b/src/tetris-main.ts
@@ -44,6 +44,7 @@ const IO = {
   left: { button: 3, machine: btnMachine },
   right: { button: 4, machine: btnMachine },
   up: { button: 2, machine: btnMachine },
+  auto: { slide: (L.TOSC % 6) + 1, machine: Math.floor(L.TOSC / 6) },
   shapeRelay: (i: number) => loc(i < 6 ? L.SHR(i, 2) : i < 9 ? L.SHR2(i, 2) : L.SHR3(i, 2)),
   lockedRelay: loc(L.LKS),
   collapseRelay: loc(L.LANE),
@@ -67,7 +68,7 @@ root.innerHTML = `
     <div id="grid" style="display:grid;grid-template-columns:repeat(${COLS},44px);gap:8px;justify-content:center"></div>
     <div id="status" style="margin-top:16px;color:#9aa3ad;min-height:1.5em">wiring the relays…</div>
     <div style="margin-top:10px;color:#5c646e">
-      &larr;/&rarr; move &nbsp;&middot;&nbsp; &uarr; = shape &nbsp;&middot;&nbsp; &darr;/space = tick &nbsp;&middot;&nbsp; enter = start &nbsp;&middot;&nbsp; m = sound
+      &larr;/&rarr; move &nbsp;&middot;&nbsp; &uarr; = shape &nbsp;&middot;&nbsp; &darr;/space = tick &nbsp;&middot;&nbsp; a = auto-gravity &nbsp;&middot;&nbsp; enter = start &nbsp;&middot;&nbsp; m = sound
     </div>
     <details style="margin-top:18px;color:#5c646e;text-align:left;max-width:520px">
       <summary style="cursor:pointer;text-align:center">dump the circuit</summary>
@@ -264,10 +265,13 @@ function render(note?: string) {
   for (let j = 0; j < COLS; j++) {
     colMarks[j].style.background = ((um >> j) & 1) === 1 ? '#7fd4ff' : 'transparent';
   }
-  const alerts = sim.getState().alerts;
+  // under AUTO the oscillator's transition solve BUZZES by design (a
+  // real relay oscillator buzzes; chatter pins de-energized) — that one
+  // alert is expected physics, not a fault, so it stays off the status
+  const alerts = sim.getState().alerts.filter(a => !(autoOn && /OSCILLATION/i.test(a)));
   status.textContent =
     note ??
-    `tick ${ticks} — score ${scoreAt()} — ${shapeLabel()}${tok >= 0 ? ` at row ${tok}` : ' (enter to spawn)'}` +
+    `tick ${ticks}${autoOn ? ' (auto)' : ''} — score ${scoreAt()} — ${shapeLabel()}${tok >= 0 ? ` at row ${tok}` : ' (enter to spawn)'}` +
       (alerts.length ? ` — ${alerts.join('; ')}` : '');
 }
 
@@ -302,11 +306,49 @@ function resyncPiece() {
   }
 }
 
+// 3b-5 auto-gravity: the AUTO slide feeds a real two-relay capacitor
+// oscillator inside the machine; the page's only job is to let TIME pass
+// (stepTime with the wall-clock delta) — the oscillator does the ticking,
+// bookkeeping runs included. The interval skips beats while a manual
+// interaction settles or after game over freezes the keyboard.
+let autoOn = false;
+let autoTimer: ReturnType<typeof setInterval> | undefined;
+let lastStep = 0;
+function setAuto(on: boolean) {
+  autoOn = on;
+  const a = IO.auto;
+  sim.setSlide(a.slide, on ? 'right' : 'left', a.machine);
+  if (on && autoTimer === undefined) {
+    lastStep = performance.now();
+    autoTimer = setInterval(() => {
+      if (busy) {
+        lastStep = performance.now();
+        return;
+      }
+      const now = performance.now();
+      const dt = Math.min(250, Math.max(80, now - lastStep));
+      lastStep = now;
+      sim.stepTime(dt);
+      ticks++;
+      render();
+    }, 130);
+  } else if (!on && autoTimer !== undefined) {
+    clearInterval(autoTimer);
+    autoTimer = undefined;
+  }
+}
+
 document.addEventListener('keydown', e => {
   if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', ' ', 'Enter'].includes(e.key)) e.preventDefault();
   if (e.key === 'm' || e.key === 'M') {
     soundOn = !soundOn;
     if (!busy) render(soundOn ? 'relay clatter on' : 'relay clatter off');
+    return;
+  }
+  if (e.key === 'a' || e.key === 'A') {
+    if (busy) return;
+    setAuto(!autoOn);
+    render(autoOn ? 'auto-gravity: the capacitor oscillator ticks the machine' : 'auto-gravity off');
     return;
   }
   if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
@@ -366,6 +408,10 @@ document.addEventListener('keydown', e => {
     // slamming press+release into one paint made every clear look like a
     // row silently vanishing.
     if (busy) return;
+    if (autoOn) {
+      render('gravity is running — press a to take the tick slide back');
+      return;
+    }
     busy = true;
     status.textContent = 'tick — relays settling…';
     const cellsBefore = Array.from({ length: ROWS }, (_, r) => rowCells(r));

--- a/src/tetris-main.ts
+++ b/src/tetris-main.ts
@@ -45,6 +45,7 @@ const IO = {
   right: { button: 4, machine: btnMachine },
   up: { button: 2, machine: btnMachine },
   auto: { slide: (L.TOSC % 6) + 1, machine: Math.floor(L.TOSC / 6) },
+  oscRelay: loc(L.TDRV), // up = the oscillator is holding the tick line high
   shapeRelay: (i: number) => loc(i < 6 ? L.SHR(i, 2) : i < 9 ? L.SHR2(i, 2) : L.SHR3(i, 2)),
   lockedRelay: loc(L.LKS),
   collapseRelay: loc(L.LANE),
@@ -67,6 +68,8 @@ root.innerHTML = `
     <div id="colrow" style="display:grid;grid-template-columns:repeat(${COLS},44px);gap:8px;justify-content:center;margin-bottom:6px"></div>
     <div id="grid" style="display:grid;grid-template-columns:repeat(${COLS},44px);gap:8px;justify-content:center"></div>
     <div id="status" style="margin-top:16px;color:#9aa3ad;min-height:1.5em">wiring the relays…</div>
+    <div style="margin-top:14px;color:#5c646e;font-size:11px">the machine wall — every armature, live</div>
+    <canvas id="wall" style="margin-top:4px;image-rendering:pixelated"></canvas>
     <div style="margin-top:10px;color:#5c646e">
       &larr;/&rarr; move &nbsp;&middot;&nbsp; &uarr; = shape &nbsp;&middot;&nbsp; &darr;/space = tick &nbsp;&middot;&nbsp; a = auto-gravity &nbsp;&middot;&nbsp; enter = start &nbsp;&middot;&nbsp; m = sound
     </div>
@@ -238,8 +241,40 @@ function rowCells(r: number): number {
 // Enter key's double-spawn interlock (a 1961 operator's discipline,
 // documented at the handler).
 
+// THE MACHINE WALL: all the minivacs as tiles on one canvas, six
+// armature dots each, redrawn directly per paint (no per-frame state —
+// the UI invariant). This is the whole multivac at a glance: the game
+// above is what those armatures are doing.
+const wall = document.getElementById('wall') as HTMLCanvasElement;
+const WALL_COLS = 17;
+const WALL_TILE_W = 26;
+const WALL_TILE_H = 16;
+const wallRows = Math.ceil(L.machines / WALL_COLS);
+wall.width = WALL_COLS * WALL_TILE_W;
+wall.height = wallRows * WALL_TILE_H;
+wall.style.width = `${wall.width}px`;
+const wctx = wall.getContext('2d')!;
+function drawWall() {
+  wctx.fillStyle = '#0a0c0f';
+  wctx.fillRect(0, 0, wall.width, wall.height);
+  for (let m = 0; m < L.machines; m++) {
+    const x = (m % WALL_COLS) * WALL_TILE_W;
+    const y = Math.floor(m / WALL_COLS) * WALL_TILE_H;
+    wctx.fillStyle = '#161a20';
+    wctx.fillRect(x + 1, y + 1, WALL_TILE_W - 2, WALL_TILE_H - 2);
+    const rel = sim.getMachineState(m).relays;
+    for (let i = 0; i < 6; i++) {
+      const rx = x + 3 + (i % 3) * 7;
+      const ry = y + 3 + Math.floor(i / 3) * 6;
+      wctx.fillStyle = rel[i] ? '#ffb000' : '#2a2f38';
+      wctx.fillRect(rx, ry, 5, 4);
+    }
+  }
+}
+
 function render(note?: string) {
   clatter();
+  drawWall();
   if (relay(IO.gameOverRelay)) {
     // the latch is relay-held: only a power cycle clears it
     for (let r = 0; r < ROWS; r++)
@@ -312,30 +347,50 @@ function resyncPiece() {
 // bookkeeping runs included. The interval skips beats while a manual
 // interaction settles or after game over freezes the keyboard.
 let autoOn = false;
+let spawnWait = false;
 let autoTimer: ReturnType<typeof setInterval> | undefined;
 let lastStep = 0;
 function setAuto(on: boolean) {
-  autoOn = on;
   const a = IO.auto;
-  sim.setSlide(a.slide, on ? 'right' : 'left', a.machine);
-  if (on && autoTimer === undefined) {
-    lastStep = performance.now();
-    autoTimer = setInterval(() => {
-      if (busy) {
-        lastStep = performance.now();
-        return;
-      }
-      const now = performance.now();
-      const dt = Math.min(250, Math.max(80, now - lastStep));
-      lastStep = now;
-      sim.stepTime(dt);
-      ticks++;
-      render();
-    }, 130);
-  } else if (!on && autoTimer !== undefined) {
+  if (on) {
+    autoOn = true;
+    sim.setSlide(a.slide, 'right', a.machine);
+    if (autoTimer === undefined) {
+      lastStep = performance.now();
+      autoTimer = setInterval(() => {
+        if (busy) {
+          lastStep = performance.now();
+          return;
+        }
+        const now = performance.now();
+        const dt = Math.min(250, Math.max(80, now - lastStep));
+        lastStep = now;
+        sim.stepTime(dt);
+        ticks++;
+        render();
+      }, 130);
+    }
+    return;
+  }
+  // taking the slide back is NOT instant: through most of each cycle the
+  // cap holds the relay pair up (slow release) with the tick line HIGH,
+  // and freezing time there wedges the line — manual ticks and STARTs
+  // are all dead against it (see the 'oscillator gaps' machine test).
+  // Cut the feed first, then keep time flowing until the driver relay
+  // has genuinely dropped (the cap drains through the coil in a couple
+  // of beats), and only then stop the clock.
+  sim.setSlide(a.slide, 'left', a.machine);
+  let low = 0;
+  for (let i = 0; i < 20 && low < 2; i++) {
+    sim.stepTime(65);
+    ticks++;
+    low = relay(IO.oscRelay) ? 0 : low + 1;
+  }
+  if (autoTimer !== undefined) {
     clearInterval(autoTimer);
     autoTimer = undefined;
   }
+  autoOn = false;
 }
 
 document.addEventListener('keydown', e => {
@@ -346,7 +401,9 @@ document.addEventListener('keydown', e => {
     return;
   }
   if (e.key === 'a' || e.key === 'A') {
-    if (busy) return;
+    // game over pins busy to freeze the game keys — but the tick slide
+    // must stay reachable, or gravity could never be stopped again
+    if (busy && !relay(IO.gameOverRelay)) return;
     setAuto(!autoOn);
     render(autoOn ? 'auto-gravity: the capacitor oscillator ticks the machine' : 'auto-gravity off');
     return;
@@ -452,6 +509,47 @@ document.addEventListener('keydown', e => {
     // the key instead of spending 8 relay contacts on an interlock.
     if (tokenRow() >= 0) {
       render('a piece is already falling');
+      return;
+    }
+    if (autoOn) {
+      // under auto the oscillator holds the tick line high through most
+      // of every cycle, and a START pressed into the high line dissipates
+      // — the arm needs a low line to survive to the next rising edge
+      // (same physics as pressing START while holding the tick slide;
+      // see the 'oscillator gaps' machine test). Wait for a beat that
+      // settled with the driver relay down, press there, and press again
+      // if the machine still swallowed it.
+      if (spawnWait) return;
+      spawnWait = true;
+      let tries = 0;
+      const tryStart = () => {
+        if (!autoOn || tokenRow() >= 0) {
+          spawnWait = false;
+          return;
+        }
+        if (busy || relay(IO.oscRelay)) {
+          setTimeout(tryStart, 45);
+          return;
+        }
+        const b = IO.start;
+        sim.pressButton(b.button, b.machine);
+        sim.releaseButton(b.button, b.machine);
+        tries++;
+        let waited = 0;
+        const check = () => {
+          if (!autoOn || tokenRow() >= 0 || tries >= 4) {
+            spawnWait = false;
+            return;
+          }
+          if (waited++ < 8) {
+            setTimeout(check, 130);
+            return;
+          }
+          setTimeout(tryStart, 45);
+        };
+        setTimeout(check, 130);
+      };
+      tryStart();
       return;
     }
     act('start', () => {

--- a/src/tetris-main.ts
+++ b/src/tetris-main.ts
@@ -25,7 +25,7 @@
  */
 
 import { MinivacSimulator, setSolverEngine } from './simulator/minivac-simulator';
-import { tetrisCircuit, NSTATES } from './circuits/multivac-mini-tetris';
+import { tetrisCircuit, SHAPES } from './circuits/multivac-mini-tetris';
 
 // the 'fast' engine: typed-array rewrite of the sparse solver, validated
 // against the dense oracle on 5000 random circuits (zero mismatches, max
@@ -105,29 +105,9 @@ for (let j = 0; j < COLS; j++) {
 document.getElementById('dump')!.textContent =
   `${wires.length} wires, ${L.machines} machines\n\n` + wires.join('\n');
 
-// the shape set — a page-side MIRROR of the machine's shape ring states:
-// a 12-state one-hot ring stepped by the UP button; this array just
-// gives each state its label and render geometry as (bottom offset and
-// width, top offset and width) — the bottom row sits at the register
-// position p+bOff, the top at p+tOff. Order MUST match the ring: the
-// L/J/T triples appended in 3b-4a, their 180-degree OVERHANG forms
-// (3-wide tops over offset single bottoms) in 3b-4c; every 2-row-box
-// orientation of the family is here.
-const SHAPES = [
-  { label: '1x1', bOff: 0, bW: 1, tOff: 0, tW: 0 },
-  { label: '2 wide', bOff: 0, bW: 2, tOff: 0, tW: 0 },
-  { label: '2 tall', bOff: 0, bW: 1, tOff: 0, tW: 1 },
-  { label: '2x2 square', bOff: 0, bW: 2, tOff: 0, tW: 2 },
-  { label: 'S', bOff: 0, bW: 2, tOff: -1, tW: 2 },
-  { label: 'Z', bOff: 0, bW: 2, tOff: 1, tW: 2 },
-  { label: 'L', bOff: 0, bW: 3, tOff: 0, tW: 1 },
-  { label: 'J', bOff: 0, bW: 3, tOff: 2, tW: 1 },
-  { label: 'T', bOff: 0, bW: 3, tOff: 1, tW: 1 },
-  { label: 'L flip', bOff: 2, bW: 1, tOff: 0, tW: 3 },
-  { label: 'J flip', bOff: 0, bW: 1, tOff: 0, tW: 3 },
-  { label: 'T flip', bOff: 1, bW: 1, tOff: 0, tW: 3 },
-] as const;
-if (SHAPES.length !== NSTATES) throw new Error('SHAPES must mirror the ring');
+// the shape set lives in the circuit file now (single source of truth
+// with the ring order and the wider-well emitter); the page only renders
+// its labels and geometry.
 // the selected shape lives IN THE RELAYS (like the position): read it back
 function shapeAt(): number {
   for (let i = 0; i < SHAPES.length; i++) if (relay(IO.shapeRelay(i))) return i;

--- a/src/tetris-main.ts
+++ b/src/tetris-main.ts
@@ -25,7 +25,7 @@
  */
 
 import { MinivacSimulator, setSolverEngine } from './simulator/minivac-simulator';
-import { tetrisCircuit, SHAPES } from './circuits/multivac-mini-tetris';
+import { tetrisCircuit, SHAPES, shapeRange } from './circuits/multivac-mini-tetris';
 
 // the 'fast' engine: typed-array rewrite of the sparse solver, validated
 // against the dense oracle on 5000 random circuits (zero mismatches, max
@@ -119,11 +119,8 @@ let ticks = 0;
 let sim: MinivacSimulator;
 const shapeLabel = () => shape().label;
 // position bounds per shape: BOTH rows must fit the well
-const minPos = () => Math.max(0, -shape().bOff, -shape().tOff);
-const maxPos = () => {
-  const s = shape();
-  return Math.min(COLS - s.bOff - s.bW, s.tW > 0 ? COLS - s.tOff - s.tW : COLS);
-};
+const minPos = () => shapeRange(shape(), COLS).min;
+const maxPos = () => shapeRange(shape(), COLS).max;
 
 function relay(loc: { machine: number; index: number }): boolean {
   return sim.getMachineState(loc.machine).relays[loc.index];
@@ -419,8 +416,7 @@ document.addEventListener('keydown', e => {
     if (p < 0) return;
     const nIx = (shapeAt() + 1) % SHAPES.length;
     const ns = SHAPES[nIx];
-    const nMin = Math.max(0, -ns.bOff, -ns.tOff);
-    const nMax = Math.min(COLS - ns.bOff - ns.bW, ns.tW > 0 ? COLS - ns.tOff - ns.tW : COLS);
+    const { min: nMin, max: nMax } = shapeRange(ns, COLS);
     const nPos = Math.min(nMax, Math.max(nMin, p));
     act(ns.label, () => {
       // the clamp = operator steps, machine-checked per the CURRENT shape

--- a/src/tetris-main.ts
+++ b/src/tetris-main.ts
@@ -280,7 +280,7 @@ function render(note?: string) {
   // under AUTO the oscillator's transition solve BUZZES by design (a
   // real relay oscillator buzzes; chatter pins de-energized) — that one
   // alert is expected physics, not a fault, so it stays off the status
-  const alerts = sim.getState().alerts.filter(a => !(autoOn && /OSCILLATION/i.test(a)));
+  const alerts = sim.getState().alerts;
   status.textContent =
     note ??
     `tick ${ticks}${autoOn ? ' (auto)' : ''} — score ${scoreAt()} — ${shapeLabel()}${tok >= 0 ? ` at row ${tok}` : ' (enter to spawn)'}` +
@@ -318,56 +318,71 @@ function resyncPiece() {
   }
 }
 
-// 3b-5 auto-gravity: the AUTO slide feeds a real two-relay capacitor
-// oscillator inside the machine; the page's only job is to let TIME pass
-// (stepTime with the wall-clock delta) — the oscillator does the ticking,
-// bookkeeping runs included. The interval skips beats while a manual
-// interaction settles or after game over freezes the keyboard.
-let autoOn = false;
-let spawnWait = false;
-let autoTimer: ReturnType<typeof setInterval> | undefined;
-let lastStep = 0;
-function setAuto(on: boolean) {
-  const a = IO.auto;
-  if (on) {
-    autoOn = true;
-    sim.setSlide(a.slide, 'right', a.machine);
-    if (autoTimer === undefined) {
-      lastStep = performance.now();
-      autoTimer = setInterval(() => {
-        if (busy) {
-          lastStep = performance.now();
-          return;
-        }
-        const now = performance.now();
-        const dt = Math.min(250, Math.max(80, now - lastStep));
-        lastStep = now;
-        sim.stepTime(dt);
+// one tick — plus however many the machine owes itself afterwards: a
+// lock leaves the LOCKED slave up until the (vertical) phase-2 write
+// and the reset have run. Auto-running them keeps the keyboard from
+// re-steering the piece between the bottom and top writes. The tick is
+// painted MID-PRESS too: a completed line is lit only while the tick
+// slide is held (the flash — CLEARP drops the row on the release), and
+// slamming press+release into one paint made every clear look like a
+// row silently vanishing.
+function runTick() {
+  busy = true;
+  status.textContent = 'tick — relays settling…';
+  const cellsBefore = Array.from({ length: ROWS }, (_, r) => rowCells(r));
+  const step = (n: number) =>
+    setTimeout(() => {
+      const t = IO.tick;
+      sim.setSlide(t.slide, 'right', t.machine);
+      render('holding the tick…');
+      setTimeout(() => {
+        sim.setSlide(t.slide, 'left', t.machine);
         ticks++;
-        render();
-      }, 130);
-    }
-    return;
-  }
-  // taking the slide back is NOT instant: through most of each cycle the
-  // cap holds the relay pair up (slow release) with the tick line HIGH,
-  // and freezing time there wedges the line — manual ticks and STARTs
-  // are all dead against it (see the 'oscillator gaps' machine test).
-  // Cut the feed first, then keep time flowing until the driver relay
-  // has genuinely dropped (the cap drains through the coil in a couple
-  // of beats), and only then stop the clock.
-  sim.setSlide(a.slide, 'left', a.machine);
-  let low = 0;
-  for (let i = 0; i < 20 && low < 2; i++) {
-    sim.stepTime(65);
-    ticks++;
-    low = relay(IO.oscRelay) ? 0 : low + 1;
-  }
-  if (autoTimer !== undefined) {
+        // the machine owes itself ticks while LOCKED (phase 2 / reset)
+        // or while a collapse walks the stack down (up to 21 more)
+        if ((relay(IO.lockedRelay) || relay(IO.collapseRelay)) && n < 3 * ROWS + 6) {
+          render(
+            relay(IO.collapseRelay)
+              ? 'line cleared — the stack falls…'
+              : 'locked — the machine runs its bookkeeping ticks…'
+          );
+          step(n + 1);
+        } else {
+          // n>0 means a lock's bookkeeping ran, i.e. the register was
+          // re-homed — shapes whose range excludes the home column need
+          // their bounds back (resync no-ops when already in range)
+          if (n > 0 && !relay(IO.gameOverRelay)) resyncPiece();
+          busy = false;
+          const cleared = cellsBefore.some((c, r) => c > 0 && rowCells(r) === 0);
+          render(cleared ? `tick ${ticks} — line cleared! the stack fell in` : undefined);
+        }
+      }, 120);
+    }, 15);
+  step(0);
+}
+
+// auto-gravity: a timer cycles the TICK SLIDE at operator cadence — the
+// same single-step path as ArrowDown, proven one row per tick. (The
+// in-machine capacitor oscillator from 3b-5 still exists and oscillates
+// — engine-parity-exact — but under the quasi-static solver its
+// transition relaxations FLUTTER and each flutter cycle reaches the
+// ring as a full tick edge: 3-4 rows per solve, reproduced identically
+// with a follower relay and a two-cap astable. The compressed-transient
+// artifact is fundamental to the relaxation semantics, so the page
+// clocks the game like a 1961 operator would: rhythmically, by hand.)
+let autoOn = false;
+let autoTimer: ReturnType<typeof setInterval> | undefined;
+function setAuto(on: boolean) {
+  autoOn = on;
+  if (on && autoTimer === undefined) {
+    autoTimer = setInterval(() => {
+      if (busy || relay(IO.gameOverRelay)) return;
+      runTick();
+    }, 700);
+  } else if (!on && autoTimer !== undefined) {
     clearInterval(autoTimer);
     autoTimer = undefined;
   }
-  autoOn = false;
 }
 
 document.addEventListener('keydown', e => {
@@ -382,7 +397,7 @@ document.addEventListener('keydown', e => {
     // must stay reachable, or gravity could never be stopped again
     if (busy && !relay(IO.gameOverRelay)) return;
     setAuto(!autoOn);
-    render(autoOn ? 'auto-gravity: the capacitor oscillator ticks the machine' : 'auto-gravity off');
+    render(autoOn ? 'auto-gravity on — the tick slide runs at operator cadence' : 'auto-gravity off');
     return;
   }
   if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
@@ -432,51 +447,8 @@ document.addEventListener('keydown', e => {
       if (shapeAt() !== nIx) return 'blocked — the contacts refused the reshape';
     });
   } else if (e.key === 'ArrowDown' || e.key === ' ') {
-    // one tick — plus however many the machine owes itself afterwards: a
-    // lock leaves the LOCKED slave up until the (vertical) phase-2 write
-    // and the reset have run. Auto-running them keeps the keyboard from
-    // re-steering the piece between the bottom and top writes. The tick is
-    // painted MID-PRESS too: a completed line is lit only while the tick
-    // slide is held (the flash — CLEARP drops the row on the release), and
-    // slamming press+release into one paint made every clear look like a
-    // row silently vanishing.
     if (busy) return;
-    if (autoOn) {
-      render('gravity is running — press a to take the tick slide back');
-      return;
-    }
-    busy = true;
-    status.textContent = 'tick — relays settling…';
-    const cellsBefore = Array.from({ length: ROWS }, (_, r) => rowCells(r));
-    const step = (n: number) =>
-      setTimeout(() => {
-        const t = IO.tick;
-        sim.setSlide(t.slide, 'right', t.machine);
-        render('holding the tick…');
-        setTimeout(() => {
-          sim.setSlide(t.slide, 'left', t.machine);
-          ticks++;
-          // the machine owes itself ticks while LOCKED (phase 2 / reset)
-          // or while a collapse walks the stack down (up to 21 more)
-          if ((relay(IO.lockedRelay) || relay(IO.collapseRelay)) && n < 3 * ROWS + 6) {
-            render(
-              relay(IO.collapseRelay)
-                ? 'line cleared — the stack falls…'
-                : 'locked — the machine runs its bookkeeping ticks…'
-            );
-            step(n + 1);
-          } else {
-            // n>0 means a lock's bookkeeping ran, i.e. the register was
-            // re-homed — shapes whose range excludes the home column need
-            // their bounds back (resync no-ops when already in range)
-            if (n > 0 && !relay(IO.gameOverRelay)) resyncPiece();
-            busy = false;
-            const cleared = cellsBefore.some((c, r) => c > 0 && rowCells(r) === 0);
-            render(cleared ? `tick ${ticks} — line cleared! the stack fell in` : undefined);
-          }
-        }, 120);
-      }, 15);
-    step(0);
+    runTick();
   } else if (e.key === 'Enter') {
     // the machine has no interlock here: START arms the SPAWN latch
     // unconditionally, and pressing it mid-fall would make the next ring
@@ -487,47 +459,7 @@ document.addEventListener('keydown', e => {
       render('a piece is already falling');
       return;
     }
-    if (autoOn) {
-      // under auto the oscillator holds the tick line high through most
-      // of every cycle, and a START pressed into the high line dissipates
-      // — the arm needs a low line to survive to the next rising edge
-      // (same physics as pressing START while holding the tick slide;
-      // see the 'oscillator gaps' machine test). Wait for a beat that
-      // settled with the driver relay down, press there, and press again
-      // if the machine still swallowed it.
-      if (spawnWait) return;
-      spawnWait = true;
-      let tries = 0;
-      const tryStart = () => {
-        if (!autoOn || tokenRow() >= 0) {
-          spawnWait = false;
-          return;
-        }
-        if (busy || relay(IO.oscRelay)) {
-          setTimeout(tryStart, 45);
-          return;
-        }
-        const b = IO.start;
-        sim.pressButton(b.button, b.machine);
-        sim.releaseButton(b.button, b.machine);
-        tries++;
-        let waited = 0;
-        const check = () => {
-          if (!autoOn || tokenRow() >= 0 || tries >= 4) {
-            spawnWait = false;
-            return;
-          }
-          if (waited++ < 8) {
-            setTimeout(check, 130);
-            return;
-          }
-          setTimeout(tryStart, 45);
-        };
-        setTimeout(check, 130);
-      };
-      tryStart();
-      return;
-    }
+    if (busy) return;
     act('start', () => {
       const b = IO.start;
       sim.pressButton(b.button, b.machine);


### PR DESCRIPTION
tracks the arcs landed on the working branch but not yet fast-forwarded to main (deploys go by gated sha once the dense scenario + oracle sweep receipts come back green).

deployed earlier from this branch: capacitor gravity (3b-5) + the machine wall and oscillator gap guards (3b-6) — live at minivac.greg.technology/tetris/ as of run 32384143712.

currently pending — the wider-well rung (column scaling toward a 6-wide well):

- **phases A+B** (0506217): `cols` threaded through `tetrisLayout` and every mechanical wiring loop; receipt = netlist byte-identical at (8,4) and (12,4). `cols !== 4` fenced until the class derivations land.
- **phase C scoping** (_notes/wider-well.md): five emitters in dependency order; per-state (db,dt) check tables verified against three hand-laid trees; mode rails proven to be geometry predicates over SHAPES; contact-set spend ledger extracted from the netlist.
- **emitter 0, the contact allocator** (a848f03): `MirrorBank` mints contact sets in request order, emits its own coil chains, enforces capacity and one-consumer-per-set; unit tested.
- **the pilot** (ab5472a): VMODEM is the first allocator-managed bank — wire-multiset identical at both geometries, ledger identical, walk test green.
- SHAPES geometry moved into the circuit file as single source of truth (91b16b7).

next: flip the exported constants to derive from `tetrisLayout(8)`, then the step-tree emitter (behaviorally gated at 4, then the width flip).